### PR TITLE
Updating start.sh with MYSQL Chown

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# Mysql CHOWN 
+chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
+sleep 10
+
 /etc/init.d/mysql start
 #create database scadalts if not exist
 sleep 10


### PR DESCRIPTION
Currently docker deployment fails because of mysql server can not start.
This update allows mysql service to get started.