### PR TITLE
#672 Correcting script.jsp "Because the script was not running on the…

### DIFF
--- a/WebContent/WEB-INF/jsp/scripting.jsp
+++ b/WebContent/WEB-INF/jsp/scripting.jsp
@@ -172,7 +172,7 @@
 		                    show($("deleteScriptImg"));
 		                    show($("executeScriptImg"));
 		                    jQuery('#executeScriptImg').click(function() {
-		                    	executeScriptImg();
+		                    	executeScript();
 		                	});
 		                }
 		                setUserMessage("<fmt:message key="scripts.saved"/>");


### PR DESCRIPTION
… UI"

It seems to me that someone in the earlier changes did replace executeScriptImg and changed the executeScript method to executeScriptImg on the occasion of the reason that the scripts were not running.