### PR TITLE
#693 Correcting too many unreadable logs

### DIFF
--- a/src/com/serotonin/mango/rt/maint/BackgroundProcessing.java
+++ b/src/com/serotonin/mango/rt/maint/BackgroundProcessing.java
@@ -18,6 +18,8 @@
  */
 package com.serotonin.mango.rt.maint;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -71,7 +73,17 @@ public class BackgroundProcessing implements ILifecycle {
 					try {
 						item.execute();
 					} catch (Throwable t) {
-						log.error("Error in work item: " + t.getMessage());
+						if (t != null) {
+							StringWriter sw = new StringWriter();
+							PrintWriter pw = new PrintWriter(sw);
+							t.printStackTrace(pw);
+							String sStackTrace = sw.toString();
+							if ((sStackTrace != null) && (log != null)) {
+								if (!sStackTrace.contains("java.lang.NullPointerException")) {
+									log.error("Error in work item: " + sStackTrace);
+								}
+							}
+						}
 					} finally {
 						mediumPriorityService.remove(this);
 					}


### PR DESCRIPTION
Because the scada create the huge logs when a problem exist
We need remove unreadable logs and When error in
Worker Process we need more information about error.