### PR TITLE
Fix to set correct imageValue type when saving and reading PointValue…

### DIFF
--- a/src/org/scada_lts/mango/service/PointValueService.java
+++ b/src/org/scada_lts/mango/service/PointValueService.java
@@ -296,10 +296,15 @@ public class PointValueService implements MangoPointValues {
             String shortString = null;
             String longString = null;
             if (svalue != null) {
-                if (svalue.length() > 128)
-                    longString = svalue;
-                else
-                    shortString = svalue;
+                if(dataType == DataTypes.IMAGE) {
+                    longString = Double.toString(dvalue);
+            		shortString = svalue;
+                } else {
+                    if (svalue.length() > 128)
+                        longString = svalue;
+                    else
+                        shortString = svalue;
+                }                
             }
 
             PointValueAdnnotation pointValueAdnnotation = new PointValueAdnnotation(id, shortString, longString, sourceType, sourceId);


### PR DESCRIPTION
Fix to set correct imageValue type when saving and reading `PointValueAdnnotation` for image point. Before this fix `textPointValueLong` was being set to `null` in `pointValueAnnotations` table for image point and when the data for point was read from database, `type` of `ImageValue` was being set to `0` even though the type of image file jpg