### PR TITLE
spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://img.shields.io/travis/grzesiekb/json.svg?style=flat-square)](https://travis-ci.org/SCADA-LTS/Scada-LTS)
 [![GPL-2.0](https://img.shields.io/npm/l/gb-json.svg?style=flat-square)](https://github.com/sdtabilit/Scada-LTS/blob/master-sdtabilit/LICENSE)
 
-Scada-LTS is an Open Source, web-based, multi-platform solution for building your own SCADA (Supervisory Control and Data Acquisiton) system.
+Scada-LTS is an Open Source, web-based, multi-platform solution for building your own SCADA (Supervisory Control and Data Acquisition) system.
 
 
 ## Table of contents


### PR DESCRIPTION
See the correct spelling at https://en.wikipedia.org/wiki/SCADA.
Also, note that your repository description (at the top of https://github.com/SCADA-LTS/Scada-LTS) also needs to be fixed.