### PR TITLE
#1103 Improvment configuration events

### DIFF
--- a/WebContent/WEB-INF/classes/env.properties
+++ b/WebContent/WEB-INF/classes/env.properties
@@ -75,7 +75,7 @@ abilit.USE_ACL=false
 abilit.ACL_SERVER=http://localhost:8090
 
 #Events
-abilit.DONT_CREATE_EVETS_FOR_EMAIL_ERROR=false
+abilit.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR=true
 
 #security.hashAlgorithm=NONE
 #grove.url=http://mango.serotoninsoftware.com/servlet

--- a/WebContent/WEB-INF/classes/env.properties
+++ b/WebContent/WEB-INF/classes/env.properties
@@ -74,6 +74,8 @@ abilit.USE_CACHE_DATA_SOURCES_POINTS_WHEN_THE_SYSTEM_IS_READY=true
 abilit.USE_ACL=false
 abilit.ACL_SERVER=http://localhost:8090
 
+#Events
+abilit.DONT_CREATE_EVETS_FOR_EMAIL_ERROR=false
 
 #security.hashAlgorithm=NONE
 #grove.url=http://mango.serotoninsoftware.com/servlet

--- a/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
+++ b/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
@@ -111,7 +111,7 @@ public class EmailWorkItem implements WorkItem {
             } catch (IOException er) {
                 LOG.error(er);
             }
-            if (!doNotCreateEventForEmailError) {
+            if (doNotCreateEventForEmailError == false) {
                 SystemEventType.raiseEvent(new SystemEventType(SystemEventType.TYPE_EMAIL_SEND_FAILURE),
                         System.currentTimeMillis(), false,
                         new LocalizableMessage("event.email.failure", subject, to, e.getMessage()));

--- a/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
+++ b/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
@@ -22,6 +22,9 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 
 import com.serotonin.mango.Common;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.scada_lts.config.ScadaConfig;
 import org.scada_lts.dao.SystemSettingsDAO;
 import com.serotonin.mango.rt.event.type.SystemEventType;
 import com.serotonin.mango.web.email.MangoEmailContent;
@@ -29,11 +32,16 @@ import com.serotonin.web.email.EmailContent;
 import com.serotonin.web.email.EmailSender;
 import com.serotonin.web.i18n.LocalizableMessage;
 
+import java.io.IOException;
+
 /**
  * @author Matthew Lohbihler
  * 
  */
 public class EmailWorkItem implements WorkItem {
+
+    private static final Log LOG = LogFactory.getLog(EmailWorkItem.class);
+
     public int getPriority() {
         return WorkItem.PRIORITY_MEDIUM;
     }
@@ -90,15 +98,24 @@ public class EmailWorkItem implements WorkItem {
             emailSender.send(fromAddress, toAddresses, subject, content);
         }
         catch (Exception e) {
+            LOG.error(e);
             String to = "";
             for (InternetAddress addr : toAddresses) {
                 if (to.length() > 0)
                     to += ", ";
                 to += addr.getAddress();
             }
-            SystemEventType.raiseEvent(new SystemEventType(SystemEventType.TYPE_EMAIL_SEND_FAILURE),
-                    System.currentTimeMillis(), false,
-                    new LocalizableMessage("event.email.failure", subject, to, e.getMessage()));
+            Boolean dontCreateEventForEmailError = false;
+            try {
+                dontCreateEventForEmailError = ScadaConfig.getInstance().getBoolean(ScadaConfig.DONT_CREATE_EVETS_FOR_EMAIL_ERROR,false);
+            } catch (IOException er) {
+                LOG.error(er);
+            }
+            if (!dontCreateEventForEmailError) {
+                SystemEventType.raiseEvent(new SystemEventType(SystemEventType.TYPE_EMAIL_SEND_FAILURE),
+                        System.currentTimeMillis(), false,
+                        new LocalizableMessage("event.email.failure", subject, to, e.getMessage()));
+            }
         }
         finally {
             if (postSendExecution != null) {

--- a/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
+++ b/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
@@ -105,13 +105,13 @@ public class EmailWorkItem implements WorkItem {
                     to += ", ";
                 to += addr.getAddress();
             }
-            Boolean dontCreateEventForEmailError = false;
+            Boolean doNotCreateEventForEmailError = false;
             try {
-                dontCreateEventForEmailError = ScadaConfig.getInstance().getBoolean(ScadaConfig.DONT_CREATE_EVETS_FOR_EMAIL_ERROR,false);
+                doNotCreateEventForEmailError = ScadaConfig.getInstance().getBoolean(ScadaConfig.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR,false);
             } catch (IOException er) {
                 LOG.error(er);
             }
-            if (!dontCreateEventForEmailError) {
+            if (!doNotCreateEventForEmailError) {
                 SystemEventType.raiseEvent(new SystemEventType(SystemEventType.TYPE_EMAIL_SEND_FAILURE),
                         System.currentTimeMillis(), false,
                         new LocalizableMessage("event.email.failure", subject, to, e.getMessage()));

--- a/src/org/scada_lts/config/ScadaConfig.java
+++ b/src/org/scada_lts/config/ScadaConfig.java
@@ -136,9 +136,9 @@ public class ScadaConfig {
 
 	private Optional<Integer> optimizationLevelJs = Optional.empty();
 
-	public static final String DONT_CREATE_EVETS_FOR_EMAIL_ERROR = "abilit.DONT_CREATE_EVETS_FOR_EMAIL_ERROR";
+	public static final String DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR = "abilit.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR";
 
-	private Optional<Boolean> dontCreateEventsForEmailError = Optional.empty();
+	private Optional<Boolean> doNotCreateEventsForEmailError = Optional.empty();
 
 
 	private static final Log LOG = LogFactory.getLog(ScadaConfig.class);
@@ -218,8 +218,8 @@ public class ScadaConfig {
 				return useACL.get();
 			} else if (HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION.equals(propertyName) && httpRetriverDoNotAllowEnableReactivation.isPresent()) {
 				return httpRetriverDoNotAllowEnableReactivation.get();
-			} else if (DONT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName) && dontCreateEventsForEmailError.isPresent()) {
-				return dontCreateEventsForEmailError.get();
+			} else if (DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName) && doNotCreateEventsForEmailError.isPresent()) {
+				return doNotCreateEventsForEmailError.get();
 			} else {
 				String propertyValue = getProperty(propertyName);
 				result = (Boolean) Boolean.parseBoolean(propertyValue);
@@ -232,8 +232,8 @@ public class ScadaConfig {
 					useACL = Optional.of(result);
 				} else if (HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION.equals(propertyName)) {
 					httpRetriverDoNotAllowEnableReactivation = Optional.of(result);
-				} else if (DONT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName)) {
-					dontCreateEventsForEmailError = Optional.of(result);
+				} else if (DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName)) {
+					doNotCreateEventsForEmailError = Optional.of(result);
 				}
 			}
 		} catch (Exception e) {

--- a/src/org/scada_lts/config/ScadaConfig.java
+++ b/src/org/scada_lts/config/ScadaConfig.java
@@ -136,6 +136,10 @@ public class ScadaConfig {
 
 	private Optional<Integer> optimizationLevelJs = Optional.empty();
 
+	public static final String DONT_CREATE_EVETS_FOR_EMAIL_ERROR = "abilit.DONT_CREATE_EVETS_FOR_EMAIL_ERROR";
+
+	private Optional<Boolean> dontCreateEventsForEmailError = Optional.empty();
+
 
 	private static final Log LOG = LogFactory.getLog(ScadaConfig.class);
 	private static final String FILE_NAME_LOGO="logo.png";
@@ -214,6 +218,8 @@ public class ScadaConfig {
 				return useACL.get();
 			} else if (HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION.equals(propertyName) && httpRetriverDoNotAllowEnableReactivation.isPresent()) {
 				return httpRetriverDoNotAllowEnableReactivation.get();
+			} else if (DONT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName) && dontCreateEventsForEmailError.isPresent()) {
+				return dontCreateEventsForEmailError.get();
 			} else {
 				String propertyValue = getProperty(propertyName);
 				result = (Boolean) Boolean.parseBoolean(propertyValue);
@@ -226,6 +232,8 @@ public class ScadaConfig {
 					useACL = Optional.of(result);
 				} else if (HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION.equals(propertyName)) {
 					httpRetriverDoNotAllowEnableReactivation = Optional.of(result);
+				} else if (DONT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName)) {
+					dontCreateEventsForEmailError = Optional.of(result);
 				}
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
I added configuration in env.properties DO_NOT_CREATE_EVETS_EVETS_FOR_EMAIL_ERROR is a switch based on which problem with sending emails is generated event or saved to the log.
DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR=false
When parameter have value  **true** then saves the problem with sending an e-mail to the log (log4j)
When parameter have value  **false** then the problem with sending an e-mail generates an event.

fix #1103