### PR TITLE
#1134 Correcting name to prm DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ branches:
   - "/^feature_s/#1115.*$/"
   - "/^feature/#1130.*$/"
   - "/^feature_s/#1128_.*$/"
+  - "/^feature/#1134.*$/"
 notifications:
   email: false
 env:

--- a/WebContent/WEB-INF/classes/env.properties
+++ b/WebContent/WEB-INF/classes/env.properties
@@ -75,7 +75,7 @@ abilit.USE_ACL=false
 abilit.ACL_SERVER=http://localhost:8090
 
 #Events
-abilit.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR=true
+abilit.DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR=true
 
 #security.hashAlgorithm=NONE
 #grove.url=http://mango.serotoninsoftware.com/servlet

--- a/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
+++ b/src/com/serotonin/mango/rt/maint/work/EmailWorkItem.java
@@ -107,7 +107,7 @@ public class EmailWorkItem implements WorkItem {
             }
             Boolean doNotCreateEventForEmailError = false;
             try {
-                doNotCreateEventForEmailError = ScadaConfig.getInstance().getBoolean(ScadaConfig.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR,false);
+                doNotCreateEventForEmailError = ScadaConfig.getInstance().getBoolean(ScadaConfig.DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR,false);
             } catch (IOException er) {
                 LOG.error(er);
             }

--- a/src/org/scada_lts/config/ScadaConfig.java
+++ b/src/org/scada_lts/config/ScadaConfig.java
@@ -136,7 +136,7 @@ public class ScadaConfig {
 
 	private Optional<Integer> optimizationLevelJs = Optional.empty();
 
-	public static final String DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR = "abilit.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR";
+	public static final String DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR = "abilit.DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR";
 
 	private Optional<Boolean> doNotCreateEventsForEmailError = Optional.empty();
 
@@ -218,7 +218,7 @@ public class ScadaConfig {
 				return useACL.get();
 			} else if (HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION.equals(propertyName) && httpRetriverDoNotAllowEnableReactivation.isPresent()) {
 				return httpRetriverDoNotAllowEnableReactivation.get();
-			} else if (DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName) && doNotCreateEventsForEmailError.isPresent()) {
+			} else if (DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR.equals(propertyName) && doNotCreateEventsForEmailError.isPresent()) {
 				return doNotCreateEventsForEmailError.get();
 			} else {
 				String propertyValue = getProperty(propertyName);
@@ -232,7 +232,7 @@ public class ScadaConfig {
 					useACL = Optional.of(result);
 				} else if (HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION.equals(propertyName)) {
 					httpRetriverDoNotAllowEnableReactivation = Optional.of(result);
-				} else if (DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR.equals(propertyName)) {
+				} else if (DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR.equals(propertyName)) {
 					doNotCreateEventsForEmailError = Optional.of(result);
 				}
 			}


### PR DESCRIPTION
Changed name parameter abilit.DO_NOT_CREATE_EVETS_FOR_EMAIL_ERROR to abilit.DO_NOT_CREATE_EVENTS_FOR_EMAIL_ERROR in config file env.properties.

fix: #1134