### PR TITLE
Fix CSS for Buttons not for Input type button #1651

### DIFF
--- a/WebContent/assets/common_deprecated.css
+++ b/WebContent/assets/common_deprecated.css
@@ -222,14 +222,18 @@ input[type="checkbox"], input[type="radio"] {
 }
 input[type="submit"], input[type="button"] {
 	overflow: visible;
+	background-color: rgb(239, 239, 239);
+	border: 1px solid var(--slts-primary);
+}
+
+#viewContent button {
+	overflow: visible;
 	background: silver;
     border-width: 3px;
     border-color: gainsboro gray gray gainsboro;
     border-style: solid;
     padding: 1px 5px;
 }
-
-
 
 /**
  * View styles


### PR DESCRIPTION
Script buttons are now visible.  
They will have the classic old-school layout.
![image](https://user-images.githubusercontent.com/22638815/116391948-1a624600-a820-11eb-81e9-aec647d8e700.png)
Classic **input type buttons** will have the same style as it was before change. 