### PR TITLE
Horizontal Scroll on GraphicalView [FIX] [Version 2.6.6]

### DIFF
--- a/WebContent/WEB-INF/jsp/viewEdit.jsp
+++ b/WebContent/WEB-INF/jsp/viewEdit.jsp
@@ -509,6 +509,15 @@
                 </tr>
               </spring:bind>
 
+              <tr><td colspan="2"><hr style="margin: 5px 0;"></td></tr>
+
+              <tr>
+                <td colspan="2" align="center">
+                  <input type="submit" name="save" value="<fmt:message key="common.save"/>" onclick="window.onbeforeunload = null;"/>
+                  <input type="submit" name="cancel" value="<fmt:message key="common.cancel"/>"/>
+                </td>
+              </tr>
+
             </table>
           </div>
         </td>
@@ -533,6 +542,12 @@
         <td>
           <input type="checkbox" id="iconifyCB" onclick="iconizeClicked();"/>
           <label for="iconifyCB"><fmt:message key="viewEdit.iconify"/></label>
+        </td>
+
+        <td class="formLabelRequired" width="350"><fmt:message key="viewEdit.viewDelete"/></td>
+        <td class="formField" width="250">
+          <input id="deleteCheckbox" type="checkbox" onclick="deleteConfirm()" style="padding-top:10px; vertical-align: middle;"/>
+          <input id="deleteButton" type="submit" name="delete" onclick="window.onbeforeunload = null; return confirm('<fmt:message key="common.confirmDelete"/>')" value="<fmt:message key="viewEdit.viewDeleteConfirm"/>" style="visibility:hidden; margin-left:15px;"/>
         </td>
 
       </tr>
@@ -567,17 +582,6 @@
             </tr>
 
             <tr><td colspan="3">&nbsp;</td></tr>
-
-            <tr>
-              <td colspan="2" align="center">
-                <input type="submit" name="save" value="<fmt:message key="common.save"/>" onclick="window.onbeforeunload = null;"/>
-                <input type="submit" name="cancel" value="<fmt:message key="common.cancel"/>"/>
-                <label style="margin-left:15px;"><fmt:message key="viewEdit.viewDelete"/></label>
-                <input id="deleteCheckbox" type="checkbox" onclick="deleteConfirm()" style="padding-top:10px; vertical-align: middle;"/>
-				<input id="deleteButton" type="submit" name="delete" onclick="window.onbeforeunload = null; return confirm('<fmt:message key="common.confirmDelete"/>')" value="<fmt:message key="viewEdit.viewDeleteConfirm"/>" style="visibility:hidden; margin-left:15px;"/>
-              </td>
-              <td></td>
-            </tr>
           </table>
         
           <div id="pointTemplate" onmouseover="revealPointControls(getViewComponentId(this))"

--- a/WebContent/assets/common_deprecated.css
+++ b/WebContent/assets/common_deprecated.css
@@ -593,3 +593,13 @@ img[src$="blue.png"], img[src$="accept.png"], img[src$="theme.png"], img[src^="i
 	margin-left:30%; 
 	margin-top:10px;
 }
+
+form.view-edit-form {
+    max-width: 100vw;
+    overflow-x: auto;
+}
+
+#viewContent {
+    max-width: 100%;
+    overflow-x: auto;
+}


### PR DESCRIPTION
Graphical View Canvas if was bigger than screen resolution it has been cropped and was not visible and accessible.

- Added CSS classes to keep the max-width of the canvas.
- Moved "Save" and "Cancel" button to the "View Properties section" (very similar as it was on VROC version)
![image](https://user-images.githubusercontent.com/22638815/122542596-29e55a80-d02b-11eb-817a-66f641f37278.png)

