### PR TITLE
Fix AmChart bug that generated multiple axes

### DIFF
--- a/scadalts-ui/src/components/amcharts/AmChart.js
+++ b/scadalts-ui/src/components/amcharts/AmChart.js
@@ -12,6 +12,7 @@ export class AmChart {
 		this.isExportId = build.isExportId || false;
 		this.isStepLineChart = build.isStepLineChart;
 
+		this.isSeparateAxis = build.isSeparateAxis;
 		this.colorPallete = build.colorPallete;
 		this.strokeWidth = build.strokeWidth || 1;
 		this.legend = build.legend;
@@ -269,7 +270,9 @@ export class AmChart {
 			case 'BinaryValue':
 			case 'MultistateValue':
 				series = this.chart.series.push(new am4charts.StepLineSeries());
-				series.yAxis = this.prepareAxisY(true, "BinaryAxis");
+				if(!this.isSeparateAxis) {
+					series.yAxis = this.prepareAxisY(true, "BinaryAxis");
+				}
 				series.startLocation = 0.5;
 				break;
 			default:
@@ -282,6 +285,9 @@ export class AmChart {
 			series.dataFields.valueY = `${pointDetails.id}`;
 		} else {
 			series.dataFields.valueY = seriesId;
+		}
+		if(!!this.isSeparateAxis) {
+			series.yAxis = this.prepareAxisY(false, `Axis${seriesId}`);
 		}
 		series.name = pointDetails.name;
 		return series;
@@ -417,6 +423,19 @@ export class AmChartBuilder {
 	 */
 	xid() {
 		this.isExportId = true;
+		return this;
+	}
+
+	/**
+	 * Separate Y Axes
+	 * 
+	 * Generate sepearate Y-axes for all
+	 * datapoint series that will be rendered
+	 * on a chart.
+	 * @returns 
+	 */
+	separateAxis() {
+		this.isSeparateAxis = true;
 		return this;
 	}
 	

--- a/scadalts-ui/src/components/amcharts/AmChart.js
+++ b/scadalts-ui/src/components/amcharts/AmChart.js
@@ -88,7 +88,6 @@ export class AmChart {
 		this.liveUpdateInterval = setInterval(async () => {
 			let newTimestamp = new Date().getTime();
 			try {
-				console.log(this.lastUpdate, newTimestamp);
 				this.chart.addData(await this.fetchPointValues(this.lastUpdate, newTimestamp));
 				this.lastUpdate = newTimestamp;
 			} catch (error) {
@@ -166,13 +165,17 @@ export class AmChart {
 	/**
 	 * @private
 	 */
-	prepareAxisY(opposite = false) {
-		let axis = this.chart.yAxes.push(new am4charts.ValueAxis());
-		axis.tooltip.disabled = false;
-		if (opposite) {
-			axis.renderer.opposite = opposite;
+	prepareAxisY(opposite = false, axisId = "NumericAxis") {
+		let axis = this.chart.yAxes.values.find(a => a.id === axisId);
+		if(!axis) {
+			axis = this.chart.yAxes.push(new am4charts.ValueAxis());
+			axis.id = axisId
+			axis.tooltip.disabled = false;
+			if (opposite) {
+				axis.renderer.opposite = opposite;
+			}
 		}
-		return axis;
+		return axis;		
 	}
 
 	/**
@@ -266,7 +269,7 @@ export class AmChart {
 			case 'BinaryValue':
 			case 'MultistateValue':
 				series = this.chart.series.push(new am4charts.StepLineSeries());
-				series.yAxis = this.prepareAxisY(true);
+				series.yAxis = this.prepareAxisY(true, "BinaryAxis");
 				series.startLocation = 0.5;
 				break;
 			default:

--- a/scadalts-ui/src/components/amcharts/LineChartComponent.vue
+++ b/scadalts-ui/src/components/amcharts/LineChartComponent.vue
@@ -36,6 +36,7 @@ export default {
 	props: {
 		pointIds: { type: String, required: true },
 		useXid: { type: Boolean },
+		separateAxis: {type: Boolean},
 		stepLine: { type: Boolean },
 		startDate: { type: String },
 		endDate: { type: String },
@@ -77,6 +78,9 @@ export default {
 
 			if (!!this.useXid) {
 				this.chartClass.xid();
+			}
+			if(!!this.separateAxis) {
+				this.chartClass.separateAxis();
 			}
 			if (!!this.stepLine) {
 				this.chartClass.stepLine();

--- a/scadalts-ui/src/components/amcharts/RangeChartComponent.vue
+++ b/scadalts-ui/src/components/amcharts/RangeChartComponent.vue
@@ -61,6 +61,7 @@ export default {
 	props: {
 		pointIds: { type: String, required: true },
 		useXid: { type: Boolean },
+		separateAxis: {type: Boolean},
 		stepLine: { type: Boolean },
 		width: { type: String, default: '500' },
 		height: { type: String, default: '400' },
@@ -100,6 +101,9 @@ export default {
 
 			if (!!this.useXid) {
 				this.chartClass.xid();
+			}
+			if (!!this.separateAxis) {
+				this.chartClass.separateAxis();
 			}
 			if (!!this.stepLine) {
 				this.chartClass.stepLine();

--- a/scadalts-ui/src/components/amcharts/readme.md
+++ b/scadalts-ui/src/components/amcharts/readme.md
@@ -150,6 +150,7 @@ Properties properties for Line charts
 | color | String | color="#FFFC19" |
 | stroke-width | Number | stroke-width="3" |
 | aggregation | Number (default=0) | aggregation="100" |
+| separate-axes | Boolean | separate-axes |
 | show-scrollbar | Boolean | show-scrollbar |
 | show-legned | Boolean | show-legned |
 | show-bullets | Boolean | show-bullets |

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -203,6 +203,7 @@ for (let x = 0; x < 10; x++) {
 					props: {
 						pointIds: el.getAttribute('point-ids'),
 						useXid: el.getAttribute('use-xid') !== null,
+						separateAxis: el.getAttribute('separate-axes') !== null,
 						stepLine: el.getAttribute('step-line') !== null,
 						startDate: el.getAttribute('start-date'),
 						endDate: el.getAttribute('end-date'),
@@ -235,6 +236,7 @@ for (let x = 0; x < 10; x++) {
 					props: {
 						pointIds: el.getAttribute('point-ids'),
 						useXid: el.getAttribute('use-xid') !== null,
+						separateAxis: el.getAttribute('separate-axes') !== null,
 						stepLine: el.getAttribute('step-line') !== null,
 						aggregation: Number(el.getAttribute('aggregation')),
 						strokeWidth: Number(el.getAttribute('stroke-width')),


### PR DESCRIPTION
If there was a binary or multistate datapoint type it has been generating more than just one axis. Now it has been fixed and by default is created "ValueAxis" but if any Binary or Numeric value is rendered a new one (but just one) y axis is created.