### PR TITLE
Upgrade Tomcat version from 9.0.52 -> 9.0.53

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     name: Compile and Test Scada-LTS application
     runs-on: ubuntu-latest
     env:
-      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.52
+      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.53
     steps:
       - uses: actions/checkout@v2
         with:
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tomcat-
       - name: Install Tomcat
-        run: mkdir -p /home/runner/tomcat; cd /home/runner/tomcat; wget https://downloads.apache.org/tomcat/tomcat-9/v9.0.52/bin/apache-tomcat-9.0.52.tar.gz; tar xvzf apache-tomcat-9.0.52.tar.gz
+        run: mkdir -p /home/runner/tomcat; cd /home/runner/tomcat; wget https://downloads.apache.org/tomcat/tomcat-9/v9.0.53/bin/apache-tomcat-9.0.53.tar.gz; tar xvzf apache-tomcat-9.0.53.tar.gz
       - name: Show Tomcat
         run: ls $CATALINA_HOME
       - name: Test JUnit Scada Application
@@ -86,7 +86,7 @@ jobs:
     needs: [compile, buildui]
     runs-on: ubuntu-latest
     env:
-      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.52
+      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.53
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,7 +15,7 @@ jobs:
     name: Compile and Test Scada-LTS application
     runs-on: ubuntu-latest
     env:
-      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.52
+      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.53
     steps:
       - uses: actions/checkout@v2
         with:
@@ -33,7 +33,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-tomcat-
       - name: Install Tomcat
-        run: mkdir -p /home/runner/tomcat; cd /home/runner/tomcat; wget https://downloads.apache.org/tomcat/tomcat-9/v9.0.52/bin/apache-tomcat-9.0.52.tar.gz; tar xvzf apache-tomcat-9.0.52.tar.gz
+        run: mkdir -p /home/runner/tomcat; cd /home/runner/tomcat; wget https://downloads.apache.org/tomcat/tomcat-9/v9.0.53/bin/apache-tomcat-9.0.53.tar.gz; tar xvzf apache-tomcat-9.0.53.tar.gz
       - name: Show Tomcat
         run: ls $CATALINA_HOME
       - name: Test JUnit Scada Application
@@ -93,7 +93,7 @@ jobs:
     needs: [compile, buildui]
     runs-on: ubuntu-latest
     env:
-      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.52
+      CATALINA_HOME: /home/runner/tomcat/apache-tomcat-9.0.53
     steps:
       - uses: actions/checkout@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Create an Scada-LTS.war file and deploy it into Docker Tomcat Image.
-FROM tomcat:9.0.52
+FROM tomcat:9.0.53
 LABEL maintainer="rjajko@softq.pl"
 COPY WebContent/WEB-INF/lib/mysql-connector-java-5.1.49.jar /usr/local/tomcat/lib/mysql-connector-java-5.1.49.jar
 COPY docker/config/context.xml /usr/local/tomcat/conf/context.xml

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 sourceCompatibility = 1.11
 targetCompatibility = 1.11
 
-def tomcatVersion = '9.0.41'
+def tomcatVersion = '9.0.53'
 def tomcatDirectory = System.getenv("CATALINA_HOME")
 
 // Environment variables to change

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ subprojects {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
On 2021-09-10 Tomcat 9.0.53 has been released and older version that we were using in GitHub Actions CI was not available. So there is an upgrade to version 9.0.53 everywhere. What is more the old jcenter() (that was marked as deprecated) repository has been shutdown and Gradle could not download the valid version of tomcat-catalina dependency. Now we have removed that and now gradle use only a mavenCentral to download packages.
