### PR TITLE
AutoManual v2 CSS fixes

### DIFF
--- a/scadalts-ui/src/components/graphical_views/cmp2/AutoManual.vue
+++ b/scadalts-ui/src/components/graphical_views/cmp2/AutoManual.vue
@@ -124,6 +124,9 @@ export default {
 		pxIdViewAndIdCmp: {
 			default: null,
 		},
+        pZeroState: {
+            default: "(N/A)",
+        },
         pWidth: {
             type: Number,
             default: 700,
@@ -193,7 +196,7 @@ export default {
          */
         async checkConditions() {
             this.loading = true;
-            this.componentState = '(N/A)';
+            this.componentState = this.pZeroState;
             const conditions = this.pConfig.state.analiseInOrder;
             for(let i = 0; i < conditions.length; i++) {
                 try {

--- a/scadalts-ui/src/components/graphical_views/cmp2/README.md
+++ b/scadalts-ui/src/components/graphical_views/cmp2/README.md
@@ -23,6 +23,7 @@ Additionaly it has additional property like `pwidth` that can be used to set the
 | pconfig | Object | Configuration of the component | *(to long to show it here)* |
 | plabel | String | Label of the component | plabel="Example label" |
 | pxIdViewAndIdCmp | String | Unique ID for the CMP | pxIdViewAndIdCmp="10" |
+| pzeroState | String | Label for state zero | pzeroState="Disabled" |
 | ptimeRefresh | Number | Time between requests | pTimeRefresh="5000" |
 | pwidth | Number | Width of the component in pixels | pwidth="1000" |
 | prequestTimeout | Number | Change the request timeout after each request is cancelled | prequestTimeout="10000" |

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -155,6 +155,7 @@ for (let i = 0; i < 10; i++) {
 						pLabel: el.getAttribute('plabel'),
 						pTimeRefresh: el.getAttribute('ptimeRefresh') !== null  ? el.getAttribute('ptimeRefresh') : 10000,
 						pxIdViewAndIdCmp: el.getAttribute('pxIdViewAndIdCmp'),
+						pZeroState: el.getAttribute('pzeroState') !== null ? el.getAttribute('pzeroState') : 'Auto',
 						pWidth: el.getAttribute('pwidth') !== null  ? el.getAttribute('pwidth') : 140,
 						pRequestTimeout: el.getAttribute('prequestTimeout') !== null ? el.getAttribute('prequestTimeout') : 5000,
 						pHideControls: el.getAttribute('phideControls') !== null,


### PR DESCRIPTION
Component was to big so added additional state x-smal when the component is smaller than 200px. Also there is default configuration to 140px width on GraphicalViews. What is more the some Vue.application CSS were fixed during the rendering on the GV.