### PR TITLE
Graphical View component: Simple Point Table

### DIFF
--- a/scadalts-ui/src/components/amcharts/AmChart.js
+++ b/scadalts-ui/src/components/amcharts/AmChart.js
@@ -5,6 +5,8 @@ import axios from 'axios';
 import { initWebSocket } from '../../web-socket';
 import store from '../../store';
 
+import { getValidDate } from '../utils.js';
+
 export class AmChart {
 	constructor(build) {
 		this.chart = null;
@@ -583,7 +585,7 @@ export class AmChartBuilder {
 	 * @returns
 	 */
 	startTime(startTimestamp) {
-		this.startTimestamp = this.getValidDate(startTimestamp);
+		this.startTimestamp = getValidDate(startTimestamp);
 		return this;
 	}
 
@@ -602,7 +604,7 @@ export class AmChartBuilder {
 	 * @returns
 	 */
 	endTime(endTimestamp) {
-		this.endTimestamp = this.getValidDate(endTimestamp);
+		this.endTimestamp = getValidDate(endTimestamp);
 		return this;
 	}
 
@@ -774,84 +776,7 @@ export class AmChartBuilder {
 		return this;
 	}
 
-	/**
-	 * Validate and conver Data
-	 * @private
-	 *
-	 * AmChart class require a numeric timestamp
-	 * to send a GET request so every date provided
-	 * by user must be converted into valid timestamp
-	 * value that will mach the further operations.
-	 *
-	 * @param {Object} date - Date to be converted
-	 * @returns {Number} valid Date timestamp
-	 */
-	getValidDate(date) {
-		if (typeof date === 'string') {
-			const regex = /\d+-((day)|(month)|(year)|(week)|(hour)|(minute))/g;
-			if (!!date.match(regex)) {
-				return this.convertDate(date);
-			} else {
-				date = new Date(date);
-				if (!isNaN(date)) {
-					return date.getTime();
-				} else {
-					throw new Error('Not valid date!');
-				}
-			}
-		} else {
-			if (date instanceof Date) {
-				return date.getTime();
-			} else {
-				return date;
-			}
-		}
-	}
-
-	/**
-	 * Convert String Data
-	 * @private
-	 *
-	 * Convert dynamic string start date
-	 * to specific timestamp.
-	 *
-	 * @param {string} dateString
-	 * @returns
-	 */
-	convertDate(dateString) {
-		let date = dateString.split('-');
-		if (date.length === 2) {
-			let now = new Date();
-			let multiplier = 1000;
-			switch (date[1]) {
-				case 'minute':
-				case 'minutes':
-					multiplier = multiplier * 60;
-					break;
-				case 'day':
-				case 'days':
-					multiplier = multiplier * 60 * 60 * 24;
-					break;
-				case 'week':
-				case 'weeks':
-					multiplier = multiplier * 60 * 60 * 24 * 7;
-					break;
-				case 'month':
-				case 'months':
-					multiplier = multiplier * 60 * 60 * 24 * 7 * 4;
-					break;
-				case 'year':
-				case 'years':
-					multiplier = multiplier * 60 * 60 * 24 * 7 * 4 * 12;
-					break;
-				default:
-					multiplier = multiplier * 60 * 60;
-			}
-			return now.getTime() - Number(date[0]) * multiplier;
-		} else {
-			throw new Error('Not valid date format! [Use for example: "1-day"]');
-		}
-	}
+	
 }
 
 export default AmChartBuilder;

--- a/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
+++ b/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
@@ -1,0 +1,181 @@
+<template>
+	<div>
+		<v-simple-table
+			class="slts-cmp--table"
+			fixed-header
+			dense
+			:style="{ maxWidth: maxWidth + 'px' }"
+			:height="maxHeight + 'px'"
+			v-if="wsConnection && retires < 5"
+		>
+			<template v-slot:default>
+				<thead>
+					<tr>
+						<th>DataPoint Name</th>
+						<th>Current Value</th>
+						<th>Last timestamp</th>
+						<th v-if="showTotal">Sum (Changes for binary)</th>
+						<th v-if="showAverage">Average</th>
+						<th v-if="showMax">Max</th>
+						<th v-if="showMin">Min</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr v-for="dp in pointState" :key="dp.name">
+						<td>{{ dp.name }}</td>
+						<td>
+							{{
+								typeof dp.current === 'number' ? dp.current.toFixed(round) : dp.current
+							}}
+						</td>
+						<td>{{ dp.lastTimestamp }}</td>
+						<td v-if="showTotal">{{ !!dp.sum ? dp.sum.toFixed(round) : dp.sum }}</td>
+						<td v-if="showAverage">{{ !!dp.avg ? dp.avg.toFixed(round) : dp.avg }}</td>
+						<td v-if="showMax">{{ dp.max }}</td>
+						<td v-if="showMin">{{ dp.min }}</td>
+					</tr>
+				</tbody>
+			</template>
+		</v-simple-table>
+		<div v-else>
+			<v-alert type="warning" dense color="orange">
+				Simple Point Table: Failed to establish connection!
+			</v-alert>
+		</div>
+	</div>
+</template>
+<script>
+import { getValidDate } from '../../utils.js';
+import BinaryDataPointEntry from './models/BinaryDataPointEntry.js';
+import NumericDataPointEntry from './models/NumericDataPointEntry.js';
+/**
+ * Simple Point Table Graphical View Component
+ *
+ * Graphical View component that can display a table of data points
+ * with their current values. It also provides the statistics for
+ * the data points from the specific time range. Connection
+ * between the server and the client is established by the
+ * websocket connection. If the component looses the connection
+ * it will inform the user about that.
+ *
+ * @author Raodslaw Jajko
+ * @version 1.0.0
+ */
+export default {
+	props: {
+		pointIds: { type: String, required: true },
+		startDate: { type: String },
+		showTotal: { type: Boolean, default: false },
+		showAverage: { type: Boolean, default: false },
+		showMax: { type: Boolean, default: false },
+		showMin: { type: Boolean, default: false },
+		round: { type: Number, default: 2 },
+		maxWidth: { type: Number, default: 600 },
+		maxHeight: { type: Number, default: 400 },
+	},
+
+	data() {
+		return {
+			startTimestamp: null,
+			endTimestamp: null,
+			pointState: [],
+			retires: 0,
+		};
+	},
+
+	computed: {
+		wsConnection() {
+			return this.$store.state.webSocketModule.webSocketConnection;
+		},
+	},
+
+	mounted() {
+		this.initTableData();
+	},
+
+	destroyed() {
+		this.pointState.forEach((p) => {
+			p.unsubscribe();
+		});
+	},
+
+	methods: {
+		initTableData() {
+			if (this.wsConnection) {
+				this.retires = 0;
+				this.initTimeRange();
+				this.initDataPointValues();
+			} else {
+				if (this.retires < 5) {
+					this.retires++;
+					setTimeout(() => {
+						this.initTableData();
+					}, 1000);
+				}
+			}
+		},
+
+		/**
+		 * Initialize the time range for the data points
+		 */
+		initTimeRange() {
+			this.endTimestamp = new Date().getTime();
+			if (!this.startDate) {
+				this.startTimestamp = this.endTimestamp - 3600000;
+			} else {
+				this.startTimestamp = getValidDate(this.startDate);
+			}
+		},
+
+		/**
+		 * Initialize the TableDataPoint entries
+		 *
+		 * Depending on the type of the datapoint,
+		 * a different model is used. This datapoints
+		 * use WebSocket connection to get the current value.
+		 */
+		initDataPointValues() {
+			const pointIds = this.pointIds.split(',');
+			const ws = this.$store.state.webSocketModule.webSocket;
+			pointIds.forEach(async (pointId) => {
+				try {
+					const { name, values, type } = await this.getDataPointHistoricValues(pointId);
+					switch (type) {
+						case 'Binary':
+							this.pointState.push(new BinaryDataPointEntry(pointId, name, values, ws));
+							break;
+						case 'Numeric':
+						case 'Multistate':
+							this.pointState.push(new NumericDataPointEntry(pointId, name, values, ws));
+							break;
+						default:
+							console.error(`Unsupported datapoint type: ${type}`);
+					}
+				} catch (e) {
+					console.error(`Failed to load DataPoint id=${pointId} values`, e);
+				}
+			});
+		},
+
+		/**
+		 * Get Data Point Values from time-range
+		 *
+		 * Fetches values from the server and returns an object with
+		 * data point details and values.
+		 * @private
+		 */
+		getDataPointHistoricValues(datapointId) {
+			return this.$store.dispatch('getDataPointValueFromTimeperiod', {
+				datapointId: datapointId,
+				startTs: this.startTimestamp,
+				endTs: this.endTimestamp,
+			});
+		},
+	},
+};
+</script>
+<style scoped>
+.slts-cmp--table {
+	overflow: auto;
+}
+</style>

--- a/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
+++ b/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
@@ -23,10 +23,10 @@
 				<tbody>
 					<tr v-for="dp in pointState" :key="dp.name">
 						<td>{{ dp.name }}</td>
-						<td>{{ dp.current | fixed(roundValue) }}</td>
+						<td>{{ dp.current | fixed(roundValue, dp.type) }}</td>
 						<td>{{ dp.lastTimestamp | localeDate }}</td>
-						<td v-if="showTotal">{{ dp.sum | fixed(roundValue) }}</td>
-						<td v-if="showAverage">{{ dp.avg | fixed(roundValue) }}</td>
+						<td v-if="showTotal">{{ dp.sum | fixed(roundValue, 'numeric') }}</td>
+						<td v-if="showAverage">{{ dp.avg | fixed(roundValue, 'numeric') }}</td>
 						<td v-if="showMax">{{ dp.max }}</td>
 						<td v-if="showMin">{{ dp.min }}</td>
 					</tr>
@@ -83,11 +83,14 @@ export default {
 		localeDate(value) {
 			return new Date(value).toLocaleString();
 		},
-		fixed: (value, precision) => {
-			if(!!precision && typeof value === 'number') {
-				return value.toFixed(precision);
-			} else {
+		fixed: (value, precision, type) => {
+			if(value !== null && value !== undefined) {
+				if(type === 'numeric' && !!precision) {
+					return value.toFixed(precision);
+				} 
 				return value;
+			} else {
+				return '-';
 			}
 		}
 	},
@@ -156,7 +159,7 @@ export default {
 							break;
 						case 'Numeric':
 						case 'Multistate':
-							this.pointState.push(new NumericDataPointEntry(pointId, name, values, ws));
+							this.pointState.push(new NumericDataPointEntry(pointId, name, values, ws, type));
 							break;
 						default:
 							console.error(`Unsupported datapoint type: ${type}`);

--- a/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
+++ b/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
@@ -23,14 +23,10 @@
 				<tbody>
 					<tr v-for="dp in pointState" :key="dp.name">
 						<td>{{ dp.name }}</td>
-						<td>
-							{{
-								typeof dp.current === 'number' ? dp.current.toFixed(round) : dp.current
-							}}
-						</td>
-						<td>{{ new Date(dp.lastTimestamp).toLocaleString() }}</td>
-						<td v-if="showTotal">{{ !!dp.sum ? dp.sum.toFixed(round) : dp.sum }}</td>
-						<td v-if="showAverage">{{ !!dp.avg ? dp.avg.toFixed(round) : dp.avg }}</td>
+						<td>{{ dp.current | fixed(roundValue) }}</td>
+						<td>{{ dp.lastTimestamp | localeDate }}</td>
+						<td v-if="showTotal">{{ dp.sum | fixed(roundValue) }}</td>
+						<td v-if="showAverage">{{ dp.avg | fixed(roundValue) }}</td>
 						<td v-if="showMax">{{ dp.max }}</td>
 						<td v-if="showMin">{{ dp.min }}</td>
 					</tr>
@@ -69,7 +65,7 @@ export default {
 		showAverage: { type: Boolean, default: false },
 		showMax: { type: Boolean, default: false },
 		showMin: { type: Boolean, default: false },
-		round: { type: Number, default: 2 },
+		roundValue: { type: Number, default: 2 },
 		maxWidth: { type: Number, default: 600 },
 		maxHeight: { type: Number, default: 400 },
 	},
@@ -83,6 +79,19 @@ export default {
 		};
 	},
 
+	filters: {
+		localeDate(value) {
+			return new Date(value).toLocaleString();
+		},
+		fixed: (value, precision) => {
+			if(!!precision && typeof value === 'number') {
+				return value.toFixed(precision);
+			} else {
+				return value;
+			}
+		}
+	},
+
 	computed: {
 		wsConnection() {
 			return this.$store.state.webSocketModule.webSocketConnection;
@@ -91,6 +100,7 @@ export default {
 
 	mounted() {
 		this.initTableData();
+		this.fix = this.roundValue;
 	},
 
 	destroyed() {

--- a/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
+++ b/scadalts-ui/src/components/graphical_views/pointTables/SimplePointTable.vue
@@ -28,7 +28,7 @@
 								typeof dp.current === 'number' ? dp.current.toFixed(round) : dp.current
 							}}
 						</td>
-						<td>{{ dp.lastTimestamp }}</td>
+						<td>{{ new Date(dp.lastTimestamp).toLocaleString() }}</td>
 						<td v-if="showTotal">{{ !!dp.sum ? dp.sum.toFixed(round) : dp.sum }}</td>
 						<td v-if="showAverage">{{ !!dp.avg ? dp.avg.toFixed(round) : dp.avg }}</td>
 						<td v-if="showMax">{{ dp.max }}</td>

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/BaseDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/BaseDataPointEntry.js
@@ -1,0 +1,29 @@
+export default class BaseDataPointEntry {
+
+    constructor(pointId, datapointName, datapointType, websocket) {
+        this.id = pointId;
+        this.name = datapointName;
+        this.type = datapointType;
+        this.current = 0;
+        this.lastTimestamp = null;
+        this.wsValueConnection = websocket;
+        if(!!this.wsValueConnection) {
+            this.subscribe();
+        }
+    }
+
+    subscribe() {
+        this.wsValueConnection.subscribe(
+            `/topic/datapoint/${this.id}/value`,
+            (data) => {this.updateValue(JSON.parse(data.body))}
+        );
+    }
+
+    unsubscribe() {
+        this.wsValueConnection.unsubscribe()
+    }
+
+    updateValue(data) {
+        throw new Error("updateValue method must be implemented in child class");        
+    }
+}

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/BinaryDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/BinaryDataPointEntry.js
@@ -1,0 +1,17 @@
+import BaseDataPointEntry from "./BaseDataPointEntry";
+
+export default class BinaryDataPointEntry extends BaseDataPointEntry {
+
+    constructor(pointId, datapointName, pointValues, websocket) {
+        super(pointId, datapointName, "binary", websocket);
+        this.sum = pointValues.length;
+        this.current = pointValues[pointValues.length - 1].value == "true" ? 1 : 0;
+        this.lastTimestamp = pointValues[pointValues.length - 1].ts;
+    }
+
+    updateValue({value}) {
+        this.current = value == "true" ? 1 : 0;
+        this.lastTimestamp = new Date().toLocaleString();
+        this.sum = this.sum++;
+    }
+}

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/BinaryDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/BinaryDataPointEntry.js
@@ -11,7 +11,7 @@ export default class BinaryDataPointEntry extends BaseDataPointEntry {
 
     updateValue({value}) {
         this.current = value == "true" ? 1 : 0;
-        this.lastTimestamp = new Date().toLocaleString();
+        this.lastTimestamp = new Date().getTime();
         this.sum = this.sum++;
     }
 }

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
@@ -2,8 +2,8 @@ import BaseDataPointEntry from "./BaseDataPointEntry";
 
 export default class NumericDataPointEntry extends BaseDataPointEntry {
 
-    constructor(pointId, datapointName, pointValues, websocket) {
-        super(pointId, datapointName, "numeric", websocket);
+    constructor(pointId, datapointName, pointValues, websocket, type) {
+        super(pointId, datapointName, type.toLowerCase(), websocket);
         this.max = 0;
         this.min = Infinity;
         this.avg = 0;

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
@@ -29,7 +29,7 @@ export default class NumericDataPointEntry extends BaseDataPointEntry {
     updateValue(data) {
         const value = Number(data.value);
         this.current = value;
-        this.lastTimestamp = new Date().toLocaleString();
+        this.lastTimestamp = new Date().getTime();
         this.sum += value;
         this.count++;
         this.min = value < this.min ? value : this.min;

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
@@ -14,7 +14,7 @@ export default class NumericDataPointEntry extends BaseDataPointEntry {
                 this.addValue(Number(value.value))
             });
         }
-        this.current = pointValues[pointValues.length - 1].value;
+        this.current = Number(pointValues[pointValues.length - 1].value);
         this.lastTimestamp = pointValues[pointValues.length - 1].ts;
     }
 

--- a/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
+++ b/scadalts-ui/src/components/graphical_views/pointTables/models/NumericDataPointEntry.js
@@ -1,0 +1,39 @@
+import BaseDataPointEntry from "./BaseDataPointEntry";
+
+export default class NumericDataPointEntry extends BaseDataPointEntry {
+
+    constructor(pointId, datapointName, pointValues, websocket) {
+        super(pointId, datapointName, "numeric", websocket);
+        this.max = 0;
+        this.min = Infinity;
+        this.avg = 0;
+        this.sum = 0;
+        this.count = 0;
+        if(pointValues.length > 0) {
+            pointValues.forEach(value => {
+                this.addValue(Number(value.value))
+            });
+        }
+        this.current = pointValues[pointValues.length - 1].value;
+        this.lastTimestamp = pointValues[pointValues.length - 1].ts;
+    }
+
+    addValue(value) {
+        this.sum += value;
+        this.count++;
+        this.min = value < this.min ? value : this.min;
+        this.max = value > this.max ? value : this.max;
+        this.avg = this.sum / this.count;
+    }
+
+    updateValue(data) {
+        const value = Number(data.value);
+        this.current = value;
+        this.lastTimestamp = new Date().toLocaleString();
+        this.sum += value;
+        this.count++;
+        this.min = value < this.min ? value : this.min;
+        this.max = value > this.max ? value : this.max;
+        this.avg = this.sum / this.count;
+    }
+}

--- a/scadalts-ui/src/components/graphical_views/pointTables/readme.md
+++ b/scadalts-ui/src/components/graphical_views/pointTables/readme.md
@@ -1,0 +1,42 @@
+# Simple Point Table Component
+
+This component add a DataPoint table to Scada-LTS Graphical Views. 
+Table present the latest data point values with a update time.
+User can use the additional properties to customize the table and
+show more details for all points. For example, the table can show 
+the average value from the specific time range or display the 
+total value of the specific point. This table works with the Numeric,
+Multistate and Boolean data points. 
+
+## Usage:
+
+User can define max 10 Simple Point Tables at the one screen.
+It is a Vue.js component so it is created like the AmCharts component
+and other components by using HTML component that need a specific
+id name and attributes to inform the renderer what to do.
+
+```
+<div id="simple-table-0" point-ids="[dataPointID]"/>
+```
+
+This table use WebSocket connection to get the latest data point values.
+
+## Simple Point Table documentation:
+
+Properties properties for Simple Point Table
+
+| Atribure name | Type | Example usage |
+| --- | --- | --- |
+| point-ids | String | point-ids="1,32,4" |
+| start-date | String | start-date="2-hours" |
+| width | Number | width="1920" |
+| height | Number | height="1080" |
+| total | Boolean | total |
+| average | Boolean | average |
+| max | Boolean | max |
+| min | Boolean | min |
+| round | Number | round="6" |
+
+# Author
+
+- [Radosław Jajko](https://github.com/radek2s): **rjajko@softq.pl**

--- a/scadalts-ui/src/components/utils.js
+++ b/scadalts-ui/src/components/utils.js
@@ -1,5 +1,77 @@
-const functionTest = function test(a, b) {
-	return a + b;
-};
+/**
+ * Validate and conver Data
+ *
+ * AmChart class require a numeric timestamp
+ * to send a GET request so every date provided
+ * by user must be converted into valid timestamp
+ * value that will mach the further operations.
+ *
+ * @param {Object} date - Date to be converted
+ * @returns {Number} valid Date timestamp
+ */
+export function getValidDate(date) {
+	if (typeof date === 'string') {
+		const regex = /\d+-((day)|(month)|(year)|(week)|(hour)|(minute))/g;
+		if (!!date.match(regex)) {
+			return convertDate(date);
+		} else {
+			date = new Date(date);
+			if (!isNaN(date)) {
+				return date.getTime();
+			} else {
+				throw new Error('Not valid date!');
+			}
+		}
+	} else {
+		if (date instanceof Date) {
+			return date.getTime();
+		} else {
+			return date;
+		}
+	}
+}
 
-module.ft = functionTest;
+/**
+ * Convert String Data
+ * @private
+ *
+ * Convert dynamic string start date
+ * to specific timestamp.
+ *
+ * @param {string} dateString
+ * @returns
+ */
+function convertDate(dateString) {
+	let date = dateString.split('-');
+	if (date.length === 2) {
+		let now = new Date();
+		let multiplier = 1000;
+		switch (date[1]) {
+			case 'minute':
+			case 'minutes':
+				multiplier = multiplier * 60;
+				break;
+			case 'day':
+			case 'days':
+				multiplier = multiplier * 60 * 60 * 24;
+				break;
+			case 'week':
+			case 'weeks':
+				multiplier = multiplier * 60 * 60 * 24 * 7;
+				break;
+			case 'month':
+			case 'months':
+				multiplier = multiplier * 60 * 60 * 24 * 7 * 4;
+				break;
+			case 'year':
+			case 'years':
+				multiplier = multiplier * 60 * 60 * 24 * 7 * 4 * 12;
+				break;
+			default:
+				multiplier = multiplier * 60 * 60;
+		}
+		return now.getTime() - Number(date[0]) * multiplier;
+	} else {
+		throw new Error('Not valid date format! [Use for example: "1-day"]');
+	}
+}

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -294,7 +294,7 @@ for (let x = 0; x < 10; x++) {
 						showAverage: el.getAttribute('average') !== null,
 						showMax: el.getAttribute('max') !== null,
 						showMin: el.getAttribute('min') !== null,
-						round: el.getAttribute('round' !== null ? Number(el.getAttribute('round')) : 2 ),
+						roundValue: Number(el.getAttribute('round')),
 						maxWidth: el.getAttribute('width' !== null ? Number(el.getAttribute('width')) : 600 ),
 						maxHeight: el.getAttribute('height' !== null ? Number(el.getAttribute('height')) : 400 ),
 					},

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -20,6 +20,7 @@ import VueLodash from 'vue-lodash';
 
 import LineChartComponent from './components/amcharts/LineChartComponent';
 import RangeChartComponent from './components/amcharts/RangeChartComponent';
+import TableComponent from './components/graphical_views/pointTables/SimplePointTable.vue'
 
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -274,6 +275,31 @@ for (let x = 0; x < 10; x++) {
 					},
 				}),
 		}).$mount(`#${chartId}`);
+	}
+}
+
+for (let x = 0; x < 10; x++) {
+	const baseId = `simple-table-${x}`;
+	const el = window.document.getElementById(baseId);
+	if (el != undefined) {
+		new Vue({
+			store,
+			vuetify,
+			render: (h) =>
+				h(TableComponent, {
+					props: {
+						pointIds: el.getAttribute('point-ids'),
+						startDate: el.getAttribute('start-date'),
+						showTotal: el.getAttribute('total') !== null,
+						showAverage: el.getAttribute('average') !== null,
+						showMax: el.getAttribute('max') !== null,
+						showMin: el.getAttribute('min') !== null,
+						round: el.getAttribute('round' !== null ? Number(el.getAttribute('round')) : 2 ),
+						maxWidth: el.getAttribute('width' !== null ? Number(el.getAttribute('width')) : 600 ),
+						maxHeight: el.getAttribute('height' !== null ? Number(el.getAttribute('height')) : 400 ),
+					},
+				}),
+		}).$mount(`#${baseId}`);
 	}
 }
 

--- a/scadalts-ui/tests/mocks/store/dataPointMock.js
+++ b/scadalts-ui/tests/mocks/store/dataPointMock.js
@@ -55,6 +55,17 @@ export const dataPoint = {
 				resolve({value: 10});
 			})
 		},
+
+		getDataPointValueFromTimeperiod({dispatch}, payload) {
+			return new Promise((resolve) => {
+				const point = {
+					name: "TestPoint",
+					type: "Numeric",
+					values: [ { value: "11.0", ts: 1637237555393}],
+				}
+				resolve(point);
+			});
+		}
 	},
 };
 

--- a/scadalts-ui/tests/mocks/store/websocketMock.js
+++ b/scadalts-ui/tests/mocks/store/websocketMock.js
@@ -1,0 +1,25 @@
+const webSocketModule = {
+    state: {
+        webSocket: null,
+        webSocketConnection: false,
+        webSocketUrl: 'http://localhost:8080/ScadaBR/ws-scada/alarmLevel',
+        debugMode: false,
+    },
+
+    mutations: {
+        INIT_WEBSOCKET(state) {
+            console.log('INIT_WEBSOCKET');            
+        },
+        INIT_WEBSOCKET_URL(state) {
+            console.log('INIT_WEBSOCKET_URL');
+        }
+    },
+
+    actions: {
+    },
+
+    getters: {
+    },
+};
+
+export default webSocketModule;

--- a/scadalts-ui/tests/unit/Components/Amcharts/AmChart.spec.js
+++ b/scadalts-ui/tests/unit/Components/Amcharts/AmChart.spec.js
@@ -3,6 +3,7 @@ import sinon from "sinon";
 import * as am4core from '@amcharts/amcharts4/core';
 import AmChart, { AmChartBuilder, AmChart as BaseAmChart }  from "../../../../src/components/amcharts/AmChart"
 import axios from "axios";
+import { getValidDate } from '../../../../src/components/utils';
 
 
 context('💠️ AmChart - base class Tests', () => {
@@ -134,107 +135,107 @@ context('💠️ AmChart - base class Tests', () => {
             let date = new Date().getTime() - 60000;
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("1-minute")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("1-minute")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "5-minutes" converted', () => {
             let date = new Date().getTime() - (60000 * 5);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("5-minutes")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("5-minutes")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "1-hour" converted', () => {
             let date = new Date().getTime() - (3600000);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("1-hour")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("1-hour")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "5-hours" converted', () => {
             let date = new Date().getTime() - (3600000 * 5);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("5-hours")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("5-hours")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "1-day" converted', () => {
             let date = new Date().getTime() - (3600000 * 24);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("1-day")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("1-day")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "5-days" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 5);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("5-days")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("5-days")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "1-week" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 7);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("1-week")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("1-week")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "2-weeks" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 7 * 2);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("2-weeks")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("2-weeks")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "1-month" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 7 * 4);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("1-month")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("1-month")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "5-months" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 7 * 4 * 5);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("5-months")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("5-months")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "1-year" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 7 * 4 * 12);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("1-year")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("1-year")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is "5-years" converted', () => {
             let date = new Date().getTime() - (3600000 * 24 * 7 * 4 * 12 * 5);
             let datePrecisionDown = date - 1;
             let datePrecisionUp = date + 1;
-            expect(chartInstance.getValidDate("5-years")).to.be.within(datePrecisionDown, datePrecisionUp);
+            expect(getValidDate("5-years")).to.be.within(datePrecisionDown, datePrecisionUp);
         })
 
         it('Is on "1-day-2" Error generated', ()=> {
-            expect(() => {chartInstance.getValidDate("1-day-2")}).to.throw();
+            expect(() => {getValidDate("1-day-2")}).to.throw();
         })
 
         it('Is on "1 day" Error generated', ()=> {
-            expect(() => chartInstance.getValidDate("1 day")).to.throw();
+            expect(() => getValidDate("1 day")).to.throw();
         })
 
         it('Is "2020-06-24" converted', () => {
             let date = new Date("2020-06-24").getTime();
-            expect(chartInstance.getValidDate("2020-06-24")).to.equal(date);
+            expect(getValidDate("2020-06-24")).to.equal(date);
         })
 
         it('Is Date object converted', () => {
             let date = new Date();
-            expect(chartInstance.getValidDate(date)).to.equal(date.getTime());
+            expect(getValidDate(date)).to.equal(date.getTime());
         })
 
         it('Is Date getTime number passed', () => {
             let date = new Date().getTime();
-            expect(chartInstance.getValidDate(date)).to.equal(date);
+            expect(getValidDate(date)).to.equal(date);
         })
     })
 

--- a/scadalts-ui/tests/unit/Components/DataPointTables/SimpleTable.spec.js
+++ b/scadalts-ui/tests/unit/Components/DataPointTables/SimpleTable.spec.js
@@ -52,7 +52,7 @@ context('💠️ Simple Table Component Tests', () => {
         });
 
         it('Prop "round" should be equal 2', () => {
-            expect(wrapper.vm.round).to.equal(2);
+            expect(wrapper.vm.roundValue).to.equal(2);
         });
 
         it('Prop "maxWidth" should be equal 600', () => {

--- a/scadalts-ui/tests/unit/Components/DataPointTables/SimpleTable.spec.js
+++ b/scadalts-ui/tests/unit/Components/DataPointTables/SimpleTable.spec.js
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import sinon from "sinon";
+import { getValidDate } from '../../../../src/components/utils';
+import { prepareMountWrapper } from "../../../utils/testing-utils";
+import webSocketModule from '../../../mocks/store/websocketMock';
+import dataPoint from '../../../mocks/store/dataPointMock';
+import SimplePointTable from '../../../../src/components/graphical_views/pointTables/SimplePointTable';
+import { is } from "core-js/core/object";
+
+
+const modules = {
+    webSocketModule,
+    dataPoint
+};
+
+global.requestAnimationFrame = (cb) => cb();
+global.cancelAnimationFrame = window.clearTimeout;
+
+context('💠️ Simple Table Component Tests', () => {
+
+    let wrapper;
+
+    describe('Component Initialization :: Default values', () => {
+        before(() => {
+            wrapper = prepareMountWrapper(SimplePointTable, modules, {
+                pointIds: '1,2'
+            });
+        });
+
+        it('Should the pointIds be equal 1,2', () => {
+            expect(wrapper.vm.pointIds).to.be.equal('1,2');    
+        })
+
+        it('Should wsConnection be false', () => {
+            expect(wrapper.vm.wsConnection).to.be.false;
+        });
+
+        it('Prop "showTotal" should be false', () => {
+            expect(wrapper.vm.showTotal).to.be.false;
+        });
+
+        it('Prop "showAverage" should be false', () => {
+            expect(wrapper.vm.showAverage).to.be.false;
+        });
+
+        it('Prop "showMax" should be false', () => {
+            expect(wrapper.vm.showMax).to.be.false;
+        });
+
+        it('Prop "showMin" should be false', () => {
+            expect(wrapper.vm.showMin).to.be.false;
+        });
+
+        it('Prop "round" should be equal 2', () => {
+            expect(wrapper.vm.round).to.equal(2);
+        });
+
+        it('Prop "maxWidth" should be equal 600', () => {
+            expect(wrapper.vm.maxWidth).to.equal(600);
+        });
+
+        it('Prop "maxHeight" should be equal 400', () => {
+            expect(wrapper.vm.maxHeight).to.equal(400);
+        });
+    })
+
+    describe('Component Initialization :: Method check', () => {
+        let response;
+        before(async () => {
+            wrapper = prepareMountWrapper(SimplePointTable, modules, {
+                pointIds: '1,2'
+            });
+            response = await wrapper.vm.getDataPointHistoricValues(1);
+        });
+
+        it('Is API response return an object',() => {
+            expect(response).to.be.an('object');
+        });
+
+        it('Is API response contain "name" property', () => {
+            expect(response).to.have.property('name');
+        });
+
+        it('Is API response contain "values" property', () => {
+            expect(response).to.have.property('values');
+        });
+
+        it('Is API response contain "type" property', () => {
+            expect(response).to.have.property('type');
+        });
+
+        it('Is InitDataPointValues method create 2 table entries', async () => {
+            wrapper.vm.initDataPointValues();
+            await wrapper.vm.$nextTick();
+            expect(wrapper.vm.pointState.length).to.equal(2);
+        });
+
+        it('Is InitTimeRange method create a start date by default from 1 hour', () => {
+            let date = new Date().getTime() - (3600000);
+            let datePrecisionDown = date - 1;
+            let datePrecisionUp = date + 1;
+            wrapper.vm.initTimeRange();
+            expect(wrapper.vm.startTimestamp).to.be.within(datePrecisionDown, datePrecisionUp);
+        })
+
+    })
+
+
+
+
+    
+
+})


### PR DESCRIPTION
This component add a DataPoint table to Scada-LTS Graphical Views.  Table present the latest data point values with a update time. User can use the additional properties to customize the table and show more details for all points. For example, the table can show the average value from the specific time range or display the total value of the specific point. This table works with the Numeric, Multistate and Boolean data points. 

## Usage:

User can define max 10 Simple Point Tables at the one screen. It is a Vue.js component so it is created like the AmCharts component and other components by using HTML component that need a specific id name and attributes to inform the renderer what to do.

```
<div id="simple-table-0" point-ids="[dataPointID]"/>
```

This table use WebSocket connection to get the latest data point values.

Full description:
[Documentation](https://github.com/SCADA-LTS/Scada-LTS/tree/feature/%231955_table_cmp_gv/scadalts-ui/src/components/graphical_views/pointTables)

To be done in a future:
More complex tables with DataPoint aggregation 