### PR TITLE
#2012 Add Global notification Store that handle the messages from any place in new UI

### DIFF
--- a/scadalts-ui/src/apps/App.vue
+++ b/scadalts-ui/src/apps/App.vue
@@ -55,6 +55,8 @@
 			</v-menu>
 		</v-app-bar>
 
+		<NotificationAlert/>
+
 		<v-main>
 			<v-container fluid>
 				<router-view></router-view>
@@ -67,13 +69,15 @@
 import webSocketMixin from '@/utils/web-socket-utils';
 import internetMixin from '@/utils/connection-status-utils';
 import NavigationBar from '../layout/NavigationBar.vue';
+import NotificationAlert from '../layout/snackbars/NotificationAlert.vue';
 
 export default {
 	name: 'app',
 	mixins: [webSocketMixin, internetMixin],
 
 	components: {
-		NavigationBar
+		NavigationBar,
+		NotificationAlert
 	},
 
 	data() {

--- a/scadalts-ui/src/layout/snackbars/NotificationAlert.vue
+++ b/scadalts-ui/src/layout/snackbars/NotificationAlert.vue
@@ -1,0 +1,35 @@
+<template>
+	<div class="alertsBox">
+		<v-alert
+			v-for="(notif, index) in scadaAlerts"
+			:key="index"
+			v-model="notif.value"
+			dismissible
+            elevation="4"
+			:type="notif.type"
+			:icon="notif.icon"
+			:color="notif.color"
+			transition="slide-x-reverse-transition"
+		>
+			{{ notif.text }}
+		</v-alert>
+	</div>
+</template>
+<script>
+export default {
+	computed: {
+		scadaAlerts() {
+			return this.$store.state.notificationModule.scadaNotifications;
+		},
+	},
+};
+</script>
+<style scoped>
+.alertsBox {
+	z-index: 1000;
+	position: fixed;
+	right: 1vw;
+	top: 80px;
+	width: 30vw;
+}
+</style>

--- a/scadalts-ui/src/layout/snackbars/SnackbarMixin.js
+++ b/scadalts-ui/src/layout/snackbars/SnackbarMixin.js
@@ -1,3 +1,6 @@
+/**
+ * @deprecated
+*/
 export const snackbarMixin = {
 	data() {
 		return {
@@ -19,6 +22,7 @@ export const snackbarMixin = {
 		 * Additionaly you can change snackbar color
 		 * or visibility duration.
 		 *
+		 * @deprecated
 		 * @param {string} message - Message to be displayed
 		 * @param {string} color - (Optional) Snackbar color
 		 * @param {number} timeout - (Optional) Visibility duration
@@ -38,7 +42,8 @@ export const snackbarMixin = {
 		 * Use generic message provider to display the
 		 * Create/Read/Update/Delete operation result status
 		 * as a snackbar.
-		 *
+		 * 
+		 * @deprecated
 		 * @param {string} type - [add, update, delete] Possible message types
 		 * @param {boolean} success - (Optional) If is failed show the 'fail' message.
 		 */

--- a/scadalts-ui/src/models/NotificationAlertEntry.js
+++ b/scadalts-ui/src/models/NotificationAlertEntry.js
@@ -1,0 +1,11 @@
+export class NotificationAlertEntry {
+    constructor(text, type = 'info', color = '', icon = null) {
+        this.value = true;
+        this.type = type;
+        this.icon = icon;
+        this.color = (type === 'info' && !color) ? 'x' : color;
+        this.text = text;
+    }
+}
+
+export default NotificationAlertEntry;

--- a/scadalts-ui/src/store/index.js
+++ b/scadalts-ui/src/store/index.js
@@ -15,6 +15,7 @@ import storeAlarmsNotifications from './alarms/notifications';
 import systemSettings from './systemSettings';
 import SynopticPanelModule from './synopticPanel';
 import watchListModule from './watchList';
+import notificationModule from './notificationStore';
 import webSocketModule from './websocketStore';
 
 import axios from 'axios';
@@ -38,6 +39,7 @@ export default new Vuex.Store({
 		pointHierarchy,
 		alarms,
 		storeUsers,
+		notificationModule,
 		userProfileModule,
 		systemSettings,
 		storeMailingList,
@@ -301,18 +303,22 @@ export default new Vuex.Store({
 		 * @param {HTTP Response} response - JSON Response from server
 		 * @returns true|false
 		 */
-		validateResponse({ state }, response) {
+		validateResponse({ state, dispatch }, response) {
 			if (!!response) {
 				if (response.status >= 200 && response.status < 300) {
 					return true;
 				} else if (response.status === 401) {
+					dispatch('showNetworkErrorNotification', 'User is not authorized!');
 					console.error('⛔️ - User is not Authorized!');
 				} else if (response.status === 400) {
+					dispatch('showNetworkErrorNotification', 'Check request data!');
 					console.error('❌️ - Bad Request! Check request data');
 				} else if (response.status === 500) {
+					dispatch('showNetworkErrorNotification', 'Server exception!');
 					console.error('🚫️ - Internal server error!\n Something went wrong!');
 				}
 			} else {
+				dispatch('showNetworkErrorNotification', 'No response received!');
 				console.error('⚫️ - Not received response message!');
 			}
 

--- a/scadalts-ui/src/store/notificationStore.js
+++ b/scadalts-ui/src/store/notificationStore.js
@@ -1,0 +1,57 @@
+import ScadaNotification from "../models/NotificationAlertEntry";
+
+const ScadaUiNotificationsModule = {
+    state: {
+        scadaNotifications: [],
+        scadaNotificationCount: 5,
+        notificationTimeoutDuration: 5000,
+        notificationTimeout: null,
+        networkError: false,
+    },
+
+    mutations: {
+        ADD_SCADA_NOTIFICATION(state, notification) {
+            state.scadaNotifications.unshift(notification);
+            if(state.scadaNotifications.length > state.scadaNotificationCount) {
+                state.scadaNotifications.pop();
+            }
+            if(!!state.notificationTimeout) { clearTimeout(state.notificationTimeout); }
+            state.notificationTimeout = setTimeout(() => {
+                state.scadaNotifications.forEach(n => n.value = false);
+            }, state.notificationTimeoutDuration)
+        },
+        SET_NETWORK_ERROR(state) {
+            state.networkError = true;
+            setTimeout(() => {
+                state.networkError = false;
+            }, 3000);
+        }
+    },
+
+    actions: {
+        showInfoNotification({commit}, text) {
+            commit('ADD_SCADA_NOTIFICATION', new ScadaNotification(text));
+        },
+        showSuccessNotification({commit}, text) {
+            commit('ADD_SCADA_NOTIFICATION', new ScadaNotification(text, 'success'));
+        },
+        showErrorNotification({commit}, text) {
+            commit('ADD_SCADA_NOTIFICATION', new ScadaNotification(text, 'error'));
+        },
+        showCustomNotification({commit}, {text, type, color, icon}) {
+            commit('ADD_SCADA_NOTIFICATION', new ScadaNotification(text, type, color, icon));
+        },
+        showNetworkErrorNotification({state, commit, dispatch}, text) { 
+            if(!state.networkError) {
+                dispatch('showErrorNotification', text);
+                commit('SET_NETWORK_ERROR');
+            }    
+        }
+
+    },
+
+    getters: { }
+
+}
+
+export default ScadaUiNotificationsModule;

--- a/scadalts-ui/src/views/Alarms/AlarmNotifications/index.vue
+++ b/scadalts-ui/src/views/Alarms/AlarmNotifications/index.vue
@@ -96,7 +96,6 @@
 				</v-row>
 			</template>
 		</v-treeview>
-		<v-snackbar v-model="snackbar.visible">{{ snackbar.text }}</v-snackbar>
 	</div>
 </template>
 <script>
@@ -125,10 +124,6 @@ export default {
 			mailingLists: undefined,
 			modified: [],
 			isError: false,
-			snackbar: {
-				visible: false,
-				text: '',
-			},
 			TYPE_MAIL: 2,
 			TYPE_SMS: 5,
 		};
@@ -416,12 +411,10 @@ export default {
 
 				this.modified = [];
 				if (this.isError) {
-					this.snackbar.text = this.$t('plcalarms.notification.fail');
-					this.snackbar.visible = true;
+					this.$store.dispatch('showErrorNotification', this.$t('plcalarms.notification.fail'));
 					this.isError = false;
 				} else {
-					this.snackbar.text = this.$t('plcalarms.notification.save');
-					this.snackbar.visible = true;
+					this.$store.dispatch('showSuccessNotification', this.$t('plcalarms.notification.save'));
 				}
 			}
 		},

--- a/scadalts-ui/src/views/DataObjects/DataPointDetails/PointProperties/PointPropEventDetectors.vue
+++ b/scadalts-ui/src/views/DataObjects/DataPointDetails/PointProperties/PointPropEventDetectors.vue
@@ -350,9 +350,6 @@
 					</v-row>
 				</v-col>
 			</v-row>
-			<v-snackbar v-model="response.status">
-				{{ response.message }}
-			</v-snackbar>
 		</v-col>
 	</v-row>
 </template>
@@ -414,10 +411,6 @@ export default {
 					value: true,
 				},
 			],
-			response: {
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -436,15 +429,13 @@ export default {
 	methods: {
 		addEventDetector(value) {
 			this.data.eventDetectors.push(value);
-			this.response.status = true;
-			this.response.message = this.$t('common.snackbar.add.success');
+			this.$store.dispatch('showSuccessNotification', this.$t('common.snackbar.add.success'))
 		},
 		addEventDetectorFail(error) {
-			this.response.status = true;
 			if(error.status === 409) {
-				this.response.message = this.$t('common.snackbar.xid.not.unique');
+				this.$store.dispatch('showErrorNotification', this.$t('common.snackbar.xid.not.unique'))
 			} else {
-				this.response.message = this.$t('common.snackbar.add.fail');
+				this.$store.dispatch('showErrorNotification', this.$t('common.snackbar.add.fail'))
 			}
 			
 		},
@@ -462,12 +453,10 @@ export default {
 					requestData: e,
 				})
 				.then((resp) => {
-					this.response.status = true;
-					this.response.message = this.$t('common.snackbar.update.success');
+					this.$store.dispatch('showSuccessNotification', this.$t('common.snackbar.update.success'))
 				})
 				.catch((err) => {
-					this.response.status = true;
-					this.response.message = this.$t('common.snackbar.update.fail');
+					this.$store.dispatch('showErrorNotification', this.$t('common.snackbar.update.fail'))
 				});
 		},
 
@@ -483,16 +472,13 @@ export default {
 							this.data.eventDetectors = this.data.eventDetectors.filter((el) => {
 								return el.id !== this.confirmDeleteDetector.id;
 							});
-							this.response.status = true;
-							this.response.message = this.$t('common.snackbar.delete.success');
+							this.$store.dispatch('showSuccessNotification', this.$t('common.snackbar.delete.success'))
 						} else {
-							this.response.status = true;
-							this.response.message = this.$t('common.snackbar.delete.fail');
+							this.$store.dispatch('showErrorNotification', this.$t('common.snackbar.delete.fail'))
 						}
 					})
 					.catch(() => {
-						this.response.status = true;
-						this.response.message = this.$t('common.snackbar.delete.fail');
+						this.$store.dispatch('showErrorNotification', this.$t('common.snackbar.delete.fail'))
 					});
 			}
 		},

--- a/scadalts-ui/src/views/DataObjects/DataPointDetails/PointProperties/PointPropLogging.vue
+++ b/scadalts-ui/src/views/DataObjects/DataPointDetails/PointProperties/PointPropLogging.vue
@@ -142,9 +142,6 @@
 				</template>
 			</v-text-field>
 		</v-col>
-		<v-snackbar v-model="response.status">
-			{{ response.message }}
-		</v-snackbar>
 	</v-row>
 </template>
 <script>
@@ -174,10 +171,6 @@ export default {
 
 	data() {
 		return {
-			response: {
-				status: false,
-				message: '',
-			},
 			consts: {
 				loggingTypes: {
 					ON_CHANGE: 1,
@@ -219,8 +212,7 @@ export default {
 	methods: {
 		clearCache() {
 			this.$store.dispatch('clearDataPointCache', this.data.id).then((resp) => {
-				this.response.status = true;
-				this.response.message = this.$t('common.snackbar.delete.success');
+				this.$store.dispatch('showSuccessNotification', this.$t('common.snackbar.delete.success'));
 			});
 		},
 	},

--- a/scadalts-ui/src/views/DataObjects/DataPointDetails/PointProperties/index.vue
+++ b/scadalts-ui/src/views/DataObjects/DataPointDetails/PointProperties/index.vue
@@ -107,9 +107,6 @@
 				<v-btn color="primary" text @click="save">{{ $t('common.save') }}</v-btn>
 			</v-card-actions>
 		</v-card>
-		<v-snackbar v-model="response.status">
-			{{ response.message }}
-		</v-snackbar>
 	</v-dialog>
 </template>
 <script>
@@ -154,10 +151,6 @@ export default {
 		return {
 			dialog: false,
 			purgeDialog: false,
-			response: {
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -186,11 +179,9 @@ export default {
 
 		purgeDataResult(result) {
 			if (result) {
-				this.response.status = true;
-				this.response.message = this.$t('common.snackbar.delete.success');
+				this.$store.dispatch('showSuccessNotification', this.$t('common.snackbar.delete.success'));				
 			} else {
-				this.response.status = true;
-				this.response.message = this.$t('common.snackbar.delete.fail');
+				this.$store.dispatch('showSuccessNotification', this.$t('common.snackbar.delete.fail'));
 			}
 			this.purgeDialog = false;
 		},

--- a/scadalts-ui/src/views/DataObjects/DataPointDetails/index.vue
+++ b/scadalts-ui/src/views/DataObjects/DataPointDetails/index.vue
@@ -77,9 +77,6 @@
 				:showLegend="true" :showScrollbar="true" :width="`${chartWidth}`"
 			></LineChartComponent>
 		</v-container>
-		<v-snackbar v-model="response.status">
-			{{ response.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
@@ -125,10 +122,6 @@ export default {
 			datasource: null,
 			chartRefreshRate: 10000,
 			chartWidth: 500,
-			response: {
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -186,13 +179,16 @@ export default {
 			this.$store
 				.dispatch('saveDataPointDetails', this.dataPointDetails)
 				.catch((e) => {
-					this.response.status = true;
-					this.response.message = `${this.$t('common.snackbar.update.fail')} | ${e.data.errors}`;
+					this.$store.dispatch(
+						'showErrorNotification', 
+						`${this.$t('common.snackbar.update.fail')} | ${e.data.errors}`)
 				})
 				.then((resp) => {
 					if (resp === 'saved') {
-						this.response.status = true;
-						this.response.message = this.$t('common.snackbar.update.success');
+						this.$store.dispatch(
+							'showSuccessNotification',
+							this.$t('common.snackbar.update.success')
+						);
 						this.$refs.valueHistory.fetchData();
 
 					}

--- a/scadalts-ui/src/views/DataObjects/PointHierarchy/index.vue
+++ b/scadalts-ui/src/views/DataObjects/PointHierarchy/index.vue
@@ -87,9 +87,6 @@
 			></EditNodeDialog>
 		</v-container>
 
-		<v-snackbar v-model="snackbar.visible" :color="snackbar.color">
-			{{ snackbar.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
@@ -97,7 +94,6 @@ import PointHierarchyNode from '@/models/PointHierarchyNode';
 import NestedNode from './NestedNode';
 import ImportExportDialog from './dialogs/ImportExportDialog';
 import EditNodeDialog from './dialogs/EditNodeDialog';
-import SnackbarMixin from '@/layout/snackbars/SnackbarMixin.js';
 
 export default {
 	components: {
@@ -105,8 +101,6 @@ export default {
 		ImportExportDialog,
 		EditNodeDialog,
 	},
-
-	mixins: [SnackbarMixin],
 
 	data() {
 		return {
@@ -162,7 +156,7 @@ export default {
 						);
 					})
 					.catch((e) => {
-						this.showSnackbar(e, 'danger');
+						this.$store.dispatch('showErrorNotification', e);
 					});
 			}
 		},
@@ -174,7 +168,7 @@ export default {
 		},
 
 		onHierarchyError(e) {
-			this.showSnackbar(e, 'danger');
+			this.$store.dispatch('showErrorNotification', e);
 		},
 	},
 };

--- a/scadalts-ui/src/views/SynopticPanel/SynopticPanelMenu.vue
+++ b/scadalts-ui/src/views/SynopticPanel/SynopticPanelMenu.vue
@@ -59,15 +59,11 @@
 			:message="$t('synopticpanels.dialog.delete.content')"
 		></ConfirmationDialog>
 
-		<v-snackbar v-model="snackbar.visible" :color="snackbar.color">
-			{{ snackbar.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
 import SynopticPanelCreator from './SynopticPanelCreator';
 import ConfirmationDialog from '@/layout/dialogs/ConfirmationDialog';
-import SnackbarMixin from '@/layout/snackbars/SnackbarMixin.js';
 
 /**
  * Synoptic Panel component - Menu Page
@@ -82,8 +78,6 @@ export default {
 		SynopticPanelCreator,
 		ConfirmationDialog,
 	},
-
-	mixins: [SnackbarMixin],
 
 	data() {
 		return {
@@ -106,11 +100,11 @@ export default {
 			this.$store
 				.dispatch('createSynopticPanel', synopticPanel)
 				.then(() => {
-					this.showCrudSnackbar('add');
+					this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.add.success`));
 					this.fetchSynopticPanelList();
 				})
 				.catch(() => {
-					this.showCrudSnackbar('add', false);
+					this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.add.fail`));
 				});
 		},
 
@@ -128,12 +122,12 @@ export default {
 				this.$store
 					.dispatch('deleteSynopticPanel', this.activePanel)
 					.then(() => {
-						this.showCrudSnackbar('delete');
+						this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.delete.success`));
 						this.fetchSynopticPanelList();
                         this.$router.push({ path: `/synoptic-panel/` });
 					})
 					.catch(() => {
-						this.showCrudSnackbar('delete', false);
+						this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.delete.fail`));
 					});
 			}
 		},
@@ -143,7 +137,11 @@ export default {
 		},
 
         onUpdatedSynopticPanel(status) {
-            this.showCrudSnackbar('update', status);
+			if(status) {
+				this.$store.dispatch('showSuccesNotification', this.$t(`common.snackbar.update.success`))
+			} else {
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.update.fail`))
+			}
         },
 
 		selectSynopticPanel(id) {

--- a/scadalts-ui/src/views/System/SystemSettings/AmChartSettingsComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/AmChartSettingsComponent.vue
@@ -40,10 +40,6 @@
                 </section>
 			</v-card-text>
 		</v-card>
-
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
@@ -56,11 +52,7 @@ export default {
 			amcharts: undefined,
 			amchartsStore: undefined,
 			isAmchartsEdited: false,
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
+			
 		};
 	},
 
@@ -83,19 +75,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.amchart'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.amchart'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 

--- a/scadalts-ui/src/views/System/SystemSettings/AuditEventTypesComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/AuditEventTypesComponent.vue
@@ -48,9 +48,7 @@
 			</v-card-text>
 		</v-card>
 
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
+		
 	</v-col>
 </template>
 <script>
@@ -64,11 +62,7 @@ export default {
 			auditEventTypes: undefined,
 			auditEventTypesStore: undefined,
 			isAuditEventEdited: false,
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
+			
 		};
 	},
 
@@ -97,19 +91,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.auditevent'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.auditevent'))
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'))
 				});
 		},
 

--- a/scadalts-ui/src/views/System/SystemSettings/DataRetentionSettingsComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/DataRetentionSettingsComponent.vue
@@ -106,9 +106,6 @@
 			@result="onDialogResult"
 		></ConfirmationDialog>
 
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
@@ -138,11 +135,6 @@ export default {
 				{ value: 6, text: this.$t('timeperiod.months') },
 				{ value: 7, text: this.$t('timeperiod.years') },
 			],
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -165,19 +157,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.dataRetention'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.dataRetention'));						
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 
@@ -254,11 +238,7 @@ export default {
 		purgeData() {
 			this.$store.dispatch('purgeData').then((resp) => {
 				if (resp === true) {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.purgedata'),
-						color: 'success',
-					};
+					this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.purgedata'));
 				}
 			});
 		},
@@ -268,21 +248,12 @@ export default {
 				.dispatch('purgeNow')
 				.then((r) => {
 					if (r.status === 'done') {
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.purgedata'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.purgedata'));
 					}
 				})
-				.catch(
-					() =>
-						(this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.fail'),
-							color: 'danger',
-						}),
-				);
+				.catch(() => {
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
+				});
 		},
 
 		convertTimePeriod: function (value, key) {

--- a/scadalts-ui/src/views/System/SystemSettings/DefaultLoggingTypeComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/DefaultLoggingTypeComponent.vue
@@ -16,9 +16,6 @@
 				></v-select>
 			</v-card-text>
 		</v-card>
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
@@ -29,11 +26,6 @@ export default {
 			defaultLoggingType: undefined,
 			defaultLoggingTypeStore: undefined,
 			isDefaultLoggingTypeEdited: false,
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -60,19 +52,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.logging'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification',this.$t('systemsettings.notification.save.logging'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification',this.$t('systemsettings.notification.fail'));
 				});
 		},
 		restoreData() {

--- a/scadalts-ui/src/views/System/SystemSettings/EmailSettingsComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/EmailSettingsComponent.vue
@@ -96,9 +96,6 @@
 			</v-card-text>
 		</v-card>
 
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
@@ -121,11 +118,6 @@ export default {
 				{ value: 1, text: this.$t('systemsettings.email.contenttype.html') },
 				{ value: 2, text: this.$t('systemsettings.email.contenttype.text') },
 			],
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -148,19 +140,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.email'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.email'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 

--- a/scadalts-ui/src/views/System/SystemSettings/HttpSettingsComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/HttpSettingsComponent.vue
@@ -53,10 +53,6 @@
 				</v-row>
 			</v-card-text>
 		</v-card>
-
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
@@ -71,11 +67,6 @@ export default {
 			httpSettingsStore: undefined,
 			isHttpSettingsEdited: false,
 			passwordVisible: false,
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -98,19 +89,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.http'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.http'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 

--- a/scadalts-ui/src/views/System/SystemSettings/MiscSettingsComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/MiscSettingsComponent.vue
@@ -23,16 +23,9 @@
 				</v-row>
 			</v-card-text>
 		</v-card>
-
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
-import { object } from '@amcharts/amcharts4/core';
-import i18n from '../../../i18n';
-
 export default {
 	name: 'MiscSettingsComponent',
 
@@ -49,11 +42,6 @@ export default {
 				},
 				{ value: 10000, text: this.$t('systemsettings.misc.performance.low') },
 			],
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -76,19 +64,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.misc'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.misc'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 
@@ -143,11 +123,7 @@ export default {
 			}).then(() => {
 				this.$store.dispatch('purgeData').then((resp) => {
 					if (resp === true) {
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.purgedata'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.purgedata'));
 					}
 				});
 			});

--- a/scadalts-ui/src/views/System/SystemSettings/SmsDomainSettingsComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/SmsDomainSettingsComponent.vue
@@ -18,10 +18,7 @@
 				</v-row>
 			</v-card-text>
 		</v-card>
-
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
+		
 	</v-col>
 </template>
 
@@ -40,11 +37,6 @@ export default {
 			domainSettings: undefined,
 			domainSettingsStore: undefined,
 			isSmsDomainSettingsEdited: false,
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -66,19 +58,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.smsdomain'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.smsdomain'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 

--- a/scadalts-ui/src/views/System/SystemSettings/SystemEventTypesComponent.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/SystemEventTypesComponent.vue
@@ -47,10 +47,6 @@
 				</v-row>
 			</v-card-text>
 		</v-card>
-
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</v-col>
 </template>
 <script>
@@ -64,11 +60,6 @@ export default {
 			systemEventTypes: undefined,
 			systemEventTypesStore: undefined,
 			isSystemEventEdited: false,
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 
@@ -97,19 +88,11 @@ export default {
 				.then((resp) => {
 					if (resp) {
 						this.restoreData();
-						this.response = {
-							status: true,
-							message: this.$t('systemsettings.notification.save.systemevent'),
-							color: 'success',
-						};
+						this.$store.dispatch('showSuccessNotification', this.$t('systemsettings.notification.save.systemevent'));
 					}
 				})
 				.catch(() => {
-					this.response = {
-						status: true,
-						message: this.$t('systemsettings.notification.fail'),
-						color: 'danger',
-					};
+					this.$store.dispatch('showErrorNotification', this.$t('systemsettings.notification.fail'));
 				});
 		},
 

--- a/scadalts-ui/src/views/System/SystemSettings/index.vue
+++ b/scadalts-ui/src/views/System/SystemSettings/index.vue
@@ -261,9 +261,6 @@
 			<v-spacer></v-spacer>
 		</v-container>
 
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
@@ -325,11 +322,6 @@ export default {
 				{ value: 'de', text: 'Deutsch' },
 				{ value: 'en', text: 'English' },
 			],
-			response: {
-				color: 'success',
-				status: false,
-				message: '',
-			},
 		};
 	},
 	mounted() {
@@ -370,16 +362,10 @@ export default {
 			});
 		},
 		generateNotification(type, content) {
-			this.response = {
-				status: true,
-				message: content,
-				color: type,
-			};
-			// this.$notify({
-			// 	placement: 'bottom-right',
-			// 	type,
-			// 	content,
-			// });
+			this.$store.dispatch('showCustomNotification', {
+				text: content,
+				type: type,
+			});
 		},
 		async loadClock() {
 			let result = await store.dispatch('getSystemStartupTime');

--- a/scadalts-ui/src/views/Users/RecipientList/index.vue
+++ b/scadalts-ui/src/views/Users/RecipientList/index.vue
@@ -96,15 +96,11 @@
 			:message="$t('recipientlist.dialog.delete.text')"
 		></ConfirmationDialog>
 
-		<v-snackbar v-model="snackbar.visible" :color="snackbar.color">
-			{{ snackbar.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
 import RecipientListDetails from './RecipientListDetails';
 import ConfirmationDialog from '@/layout/dialogs/ConfirmationDialog';
-import SnackbarMixin from '@/layout/snackbars/SnackbarMixin.js';
 
 /**
  * Recipient List component - View page.
@@ -128,8 +124,6 @@ export default {
 		RecipientListDetails,
 		ConfirmationDialog,
 	},
-
-	mixins: [SnackbarMixin],
 
 	data() {
 		return {
@@ -170,7 +164,7 @@ export default {
 					this.activeRecipientList.id,
 				);
 				let operationSuccess = !!resp.status && resp.status === 'deleted';
-				this.showCrudSnackbar('delete', operationSuccess);
+				this.$store.dispatch('showSuccessNotification', "Deleted successfully");
 				if (operationSuccess) {
 					this.activeRecipientList = null;
 					this.fetchRecipeintLists();
@@ -190,7 +184,7 @@ export default {
 			this.$refs.recipientListDialog.preSave();
 			let resp = await this.$store.dispatch('createMailingList', this.blankRecipientList);
 			let operationSuccess = !!resp.status && resp.status === 'created';
-			this.showCrudSnackbar('add', operationSuccess);
+			this.$store.dispatch('showSuccessNotification', "Created successfully");
 			if (operationSuccess) {
 				this.fetchRecipeintLists();
 			}
@@ -198,7 +192,12 @@ export default {
 		},
 
 		updateRecipientList(resp) {
-			this.showCrudSnackbar('update', !!resp.status && resp.status === 'updated');
+			if(resp.status === 'updated') {
+				this.$store.dispatch('showSuccessNotification', "Updated successfully");
+				this.fetchRecipeintLists();
+			} else {
+				this.$store.dispatch('showErrorNotification', "Error while updating");
+			}
 		},
 	},
 };

--- a/scadalts-ui/src/views/Users/UserList/index.vue
+++ b/scadalts-ui/src/views/Users/UserList/index.vue
@@ -114,15 +114,11 @@
 			:message="$t('userDetails.dialog.delete.text')"
 		></ConfirmationDialog>
 
-		<v-snackbar v-model="snackbar.visible" :color="snackbar.color">
-			{{ snackbar.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
 import UserDetails from './UserDetails';
 import ConfirmationDialog from '@/layout/dialogs/ConfirmationDialog';
-import SnackbarMixin from '@/layout/snackbars/SnackbarMixin.js';
 
 /**
  * User List component - View page.
@@ -142,8 +138,6 @@ export default {
 		UserDetails,
 		ConfirmationDialog,
 	},
-
-	mixins: [SnackbarMixin],
 
 	data() {
 		return {
@@ -232,9 +226,9 @@ export default {
 				if(this.selectedUser.id === userId) {
 					this.selectedUser = null;
 				}
-				this.showCrudSnackbar('delete')
+				this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.delete.success`));
 			} catch (e) {
-				this.showCrudSnackbar('delete', false)
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.delete.fail`));
 				console.error(e);
 			}			
 		},
@@ -253,10 +247,10 @@ export default {
 				requestData.password = this.userPassword;
 				try {
 					await this.$store.dispatch('createUser', requestData);
-					this.showCrudSnackbar('add');
+					this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.add.success`));
 					this.fetchUserList();
 				} catch (e) {
-					this.showCrudSnackbar('add', false);
+					this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.add.fail`));
 				}
 			}
         },
@@ -268,20 +262,26 @@ export default {
 		async onUpdateUserDetails() {
 			try {
 				await this.$store.dispatch('updateUser', this.selectedUser);
-				this.showCrudSnackbar('update');
+				this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.update.success`));
 			} catch (e) {
-				this.showCrudSnackbar('update', false);
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.update.fail`));
 			}
 		},
 
 		onPasswordChanged(result) {
-			this.showCrudSnackbar('update', result);
+			if(result) {
+				this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.update.success`));
+			} else {
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.update.fail`));
+			}
 		},
 
 		onUserProfileCreated(result) {
-			this.showCrudSnackbar('add', result);
 			if(result) {
+				this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.add.success`));
 				this.fetchUserProfiles();
+			} else {
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.add.fail`));
 			}
 		}
 

--- a/scadalts-ui/src/views/Users/UserProfiles/index.vue
+++ b/scadalts-ui/src/views/Users/UserProfiles/index.vue
@@ -106,16 +106,11 @@
 			:message="$t('userprofile.dialog.delete.text')"
 		></ConfirmationDialog>
 
-
-		<v-snackbar v-model="snackbar.visible" :color="snackbar.color">
-			{{ snackbar.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
 import UserProfileDetails from './UserProfileDetails.vue';
 import ConfirmationDialog from '@/layout/dialogs/ConfirmationDialog';
-import SnackbarMixin from '@/layout/snackbars/SnackbarMixin.js';
 
 /**
  * User Profile List component - View Page
@@ -133,8 +128,6 @@ export default {
         UserProfileDetails,
 		ConfirmationDialog
     },
-
-	mixins: [SnackbarMixin],
 
 	data() {
 		return {
@@ -187,9 +180,9 @@ export default {
 			if (result) {
 				try {
 					this.deleteUserProfile(this.operationQueue);
-					this.showCrudSnackbar('delete')
+					this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.delete.success`));
 				} catch (e) {
-					this.showCrudSnackbar('delete', false)
+					this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.delete.fail`));
 					console.error(e);
 				}
 			}
@@ -207,18 +200,18 @@ export default {
 		/* EVENTS FROM CHILD COMPONENTS */
 		onUserProfileUpdate(result) {
 			if (result) {
-				this.showCrudSnackbar('update')
+				this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.update.success`));
 			} else {
-				this.showCrudSnackbar('update', false)
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.update.fail`));
 			}
         },
 
 		onUserProfileCreation(result) {
 			if (result) {
-				this.showCrudSnackbar('add')
+				this.$store.dispatch('showSuccessNotification', this.$t(`common.snackbar.add.success`));
 				this.fetchUserProfileList();
 			} else {
-				this.showCrudSnackbar('add', false)
+				this.$store.dispatch('showErrorNotification', this.$t(`common.snackbar.add.fail`));
 			}
 		},
 		

--- a/scadalts-ui/src/views/WatchList/PointChart/index.vue
+++ b/scadalts-ui/src/views/WatchList/PointChart/index.vue
@@ -79,9 +79,6 @@
 				<div class="chartContainer" ref="chartdiv"></div>
 			</v-col>
 		</v-row>
-		<v-snackbar v-model="response.status" :color="response.color">
-			{{ response.message }}
-		</v-snackbar>
 	</div>
 </template>
 <script>
@@ -129,11 +126,6 @@ export default {
 			config: null,
 			// watchListData: {id: 1, pointList: [{id:1},{id:2}]}, -> this.activeWatchList.id
 			pointCompare: '',
-			response: {
-				status: false,
-				color: '',
-				message: '',
-			},
 		};
 	},
 
@@ -218,17 +210,12 @@ export default {
 		renderChart() {
 			this.chartClass.createChart().catch((e) => {
 				if (e.message === 'No data from that range!') {
-					this.response = {
-						status: true,
-						color: 'warning',
-						message: e.message,
-					};
+					this.$store.dispatch('showCustomNotification', {
+						text: e.message,
+						type: 'warning',
+					})
 				} else {
-					this.response = {
-						status: true,
-						color: 'error',
-						message: `Failed to load chart!: ${e.message}`,
-					};
+					this.$store.dispatch('showErrorNotification', `Failed to load chart!: ${e.message}`);
 				}
 			});
 		},

--- a/scadalts-ui/tests/unit/DataPointDetails/PointPropLogging.spec.js
+++ b/scadalts-ui/tests/unit/DataPointDetails/PointPropLogging.spec.js
@@ -66,7 +66,8 @@ context('💠️ Test Point Properties - Logging Scenario', () => {
 
 		it('Clear DataPoint cache', async () => {
 			await wrapper.vm.clearCache();
-			expect(wrapper.vm.response.status).to.equal(true);
+			//There is no way to check the notification message
+			// expect(wrapper.vm.response.status).to.equal(true);
 		});
 
 	})


### PR DESCRIPTION
All snackbar imports and  messages are now replaced by new Notification Component that handle the notification messages and show them in top right corner of the application. This mechanism is binded with global HTTP requests methods so when it receives a error message user is informed about that error so the developer don't have to worry about common errors.

![image](https://user-images.githubusercontent.com/22638815/147329226-26181c63-5e91-456f-afe8-94b54ed89245.png)
