### PR TITLE
Bugfix for non-Admin user on the new UI. 

### DIFF
--- a/scadalts-ui/src/apps/App.vue
+++ b/scadalts-ui/src/apps/App.vue
@@ -12,10 +12,10 @@
 					</v-list-item-subtitle>
 				</v-list-item-content>
 			</v-list-item>
-			<v-list-item max-width="50">
+			<v-list-item max-width="50" v-if="!!highestUnsilencedAlarmLevel">
 				<v-list-item-content>
 					<a @click="goToEvents" :style="{cursor: (this.$route.name==='scada')? 'auto':'pointer'}">
-						<img v-if="highestUnsilencedAlarmLevel != -1" :src="alarmFlags[highestUnsilencedAlarmLevel].image"/>
+						<img v-if="highestUnsilencedAlarmLevel !== -1" :src="alarmFlags[highestUnsilencedAlarmLevel].image"/>
 					</a>
 				</v-list-item-content>
 			</v-list-item>

--- a/src/org/scada_lts/web/mvc/api/SystemSettingsAPI.java
+++ b/src/org/scada_lts/web/mvc/api/SystemSettingsAPI.java
@@ -407,7 +407,7 @@ public class SystemSettingsAPI {
     public ResponseEntity<JsonSettingsSystemInfo> getSystemInfo(HttpServletRequest request) {
         try {
             User user = Common.getUser(request);
-            if (user != null && user.isAdmin()) {
+            if (user != null) {
                 return new ResponseEntity<>(systemSettingsService.getSystemInfoSettings(), HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);

--- a/src/org/scada_lts/web/mvc/api/WatchListAPI.java
+++ b/src/org/scada_lts/web/mvc/api/WatchListAPI.java
@@ -116,7 +116,7 @@ public class WatchListAPI {
 	public ResponseEntity<String> getUniqueXid(HttpServletRequest request) {
 		try {
 			User user = Common.getUser(request);
-			if(user != null && user.isAdmin()) {
+			if(user != null) {
 				return new ResponseEntity<>(watchListService.generateUniqueXid(), HttpStatus.OK);
 			} else {
 				return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
Due to some works related to the New UI in version 2.7.1 when we were logged as non admin user we could not open the User Details page. Also the WatchList produced authorization error because the GetAllDataPoints method was trying to download all DataPoints in Scada. But now it has been improved to respect the "read" permission and user now will see all the data points to which he has at least read access. 

Some other methods that caused this error has been fixed.

**How to check if everything is ok?**
1. Login into the Scada-LTS as `admin` user.
2. Make sure that you have at least 3 DataPoints (all points should have enabled property "settable")
3. Create a `userProfile` by opening the User Profile page.
4. Change the access to data points:
  a. 1st data point with none permission
  b. 2nd data point with read permission
  c. 3rd data point with set permission
5. Create a new non-admin user called `user1` with your UserProfile access list.
6. Log out and log-in as user1
7. Move to the new UI
8. Open the "account settings" in top right corner and open "edit profile" page.
9. Page should be loaded.
10. Move to the WatchList and create a new one. 
11. Start typing the DataPoint names in search box. 
12. Add them by clicking "apply" button next to the search box.
13. Create watch list.
14. You should have only access to 2 data points.
15. Try to open the DataPoint details by clicking "info button".
16. Permission denied page should be visible.

