### PR TITLE
Watchdog component

### DIFF
--- a/scadalts-ui/src/components/graphical_views/watchdog/CheckError.js
+++ b/scadalts-ui/src/components/graphical_views/watchdog/CheckError.js
@@ -1,0 +1,12 @@
+export default class CheckError extends Error {
+    constructor(message = 'Validation check error', ...params) {
+        super(...params);
+
+        if(Error.captureStackTrace) {
+            Error.captureStackTrace(this, CheckError);
+        }
+
+        this.message = message;
+        this.date = new Date();
+    }
+}

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -1,0 +1,26 @@
+# Watchdog component
+This is a new version of classic IsAlive component that is able to detect the System offline state. If the client browser is offline, when there is no response from the server or 
+when specific datapoint does not meet the specified criteria, the component will show the offline state. If the Watchdog server is defined this compoenent will send the request 
+to this server using the TCP socket connection. 
+
+## Configuration
+
+Example datapoint condition configuration:
+```javascript
+[{
+    xid: 'DP01',
+    value: 1,
+    check: 'equal'
+}]
+```
+
+User can provide the data point configuration to check if the system is online based on the 
+datapoint condition value. 
+
+| Check type | Description |
+| ---------- | ----------- |
+| `equal` | Check if the value is equal to the specified value |
+| `less` | Check if the value is less than the specified value |
+| `greater` | Check if the value is greater than the specified value |
+| `less_equal` | Check if the value is less than or equal to the specified value |
+| `greater_equal` | Check if the value is greater than or equal to the specified value |

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -3,6 +3,17 @@ This is a new version of classic IsAlive component that is able to detect the Sy
 when specific datapoint does not meet the specified criteria, the component will show the offline state. If the Watchdog server is defined this compoenent will send the request 
 to this server using the TCP socket connection. 
 
+Watchdog server will receive the message with format:
+```
+<requestHostAddr>|<message>
+```
+where the `requestHostAddr` is the address of the client browser that was sending the request. 
+`message` by default will be "ping" unless user not defined the `dp-message` argument in his
+UI component. This is required because the Scada-LTS application runs on the specific server machine that might be different from the client browser. So to identify the browser that 
+is sending the request we are providing that address and additional message to the socket
+connection. 
+
+
 ## Configuration
 
 Example datapoint condition configuration:
@@ -33,6 +44,7 @@ datapoint condition value.
 | `interval` | number (optional) | 10000 | Interval time between checking the application health |
 | `wd-ip` | string (optional) | null | IP address to the WatchDog server |
 | `wd-port` | number (optional) | null | Port number to WatchDog server |
+| `wd-message` | string (optional) | 'ping' | Message that will be send thought the TCP socket connection to the WatchDog server |
 | `dp-validation` | array (optional) | null | Array of objects that contains the DP check validation |
 | `dp-failure` | boolean | false | If that argument exists that means the DP check error will be treated as failure |
 
@@ -45,11 +57,17 @@ Watchdog component can be used in the following way:
 <div id="app-isalive2" 
     name="test2" 
     interval="3000" 
-    wd-ip="172.0.0.1" 
+    wd-ip="127.0.0.1" 
     wd-port="1234" 
+    wd-message="Monitoring"
     dp-validation='[{"xid":"DP_EN1", "value":1, "check":"equal"}]' 
     dp-failure
 ></div>
 ```
 To embed this component in the page we need to add the new HTML component to our view and then create a following div with "app-isalive2" id. Rest of the parameters are optional.
 
+To create your own watchdog server you can use the following command:
+```bash
+nc -4 -l 127.0.0.1 1234
+```
+When the component will check every step you should see the message received from the Scada client.

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -24,3 +24,32 @@ datapoint condition value.
 | `greater` | Check if the value is greater than the specified value |
 | `less_equal` | Check if the value is less than or equal to the specified value |
 | `greater_equal` | Check if the value is greater than or equal to the specified value |
+
+## API
+
+| Parameter name | type |  Default | Description |
+| ---------- | ----------- | ----------- | ----------- |
+| `name` | string (optional) | 'IsAlive2' | Name that will be displayed as the menu title |
+| `interval` | number (optional) | 10000 | Interval time between checking the application health |
+| `wd-ip` | string (optional) | null | IP address to the WatchDog server |
+| `wd-port` | number (optional) | null | Port number to WatchDog server |
+| `dp-validation` | array (optional) | null | Array of objects that contains the DP check validation |
+| `dp-failure` | boolean | false | If that argument exists that means the DP check error will be treated as failure |
+
+
+
+## Example usage
+
+Watchdog component can be used in the following way:
+```html
+<div id="app-isalive2" 
+    name="test2" 
+    interval="3000" 
+    wd-ip="172.0.0.1" 
+    wd-port="1234" 
+    dp-validation='[{"xid":"DP_EN1", "value":1, "check":"equal"}]' 
+    dp-failure
+></div>
+```
+To embed this component in the page we need to add the new HTML component to our view and then create a following div with "app-isalive2" id. Rest of the parameters are optional.
+

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -1,7 +1,5 @@
 # Watchdog component
-This is a new version of classic IsAlive component that is able to detect the System offline state. If the client browser is offline, when there is no response from the server or 
-when specific datapoint does not meet the specified criteria, the component will show the offline state. If the Watchdog server is defined this compoenent will send the request 
-to this server using the TCP socket connection. 
+This is a new version of classic IsAlive component that is able to detect the System offline state. If the client browser is offline, when there is no response from the server or when specific datapoint does not meet the specified criteria, the component will show the offline state. If the Watchdog server is defined this compoenent will send the request to this server using the TCP socket connection. 
 
 Watchdog server will receive the message with format:
 ```
@@ -25,8 +23,7 @@ Example datapoint condition configuration:
 }]
 ```
 
-User can provide the data point configuration to check if the system is online based on the 
-datapoint condition value. 
+User can provide the data point configuration to check if the system is online based on the datapoint condition value. By default any error in this DataPoint condition checking generates an "warning" message that is displayed on the component. If user want's to break the condition checking process when the first error occured he can add `dp-break` parameter to this component.  Warning message is not blocking the Watchdog Notification Process. If any error on the check should be treated as a "fail" instead of "warning" to break this communication flow user can add the `dp-failure` parameter. 
 
 | Check type | Description |
 | ---------- | ----------- |
@@ -47,7 +44,7 @@ datapoint condition value.
 | `wd-message` | string (optional) | 'ping' | Message that will be send thought the TCP socket connection to the WatchDog server |
 | `dp-validation` | array (optional) | null | Array of objects that contains the DP check validation |
 | `dp-break` | boolean (optional) | false | If that argument is set the datapoint check will be break if the datapoint is not valid |
-| `dp-failure` | boolean | false | If that argument exists that means the DP check error will be treated as failure |
+| `dp-failure` | boolean | false | If that argument exists that means the DP check error is changed from "warning" to "failure". Failure in any step is stopping the notification sending process.  |
 
 
 

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -42,7 +42,7 @@ datapoint condition value.
 | ---------- | ----------- | ----------- | ----------- |
 | `name` | string (optional) | 'IsAlive2' | Name that will be displayed as the menu title |
 | `interval` | number (optional) | 10000 | Interval time between checking the application health |
-| `wd-ip` | string (optional) | null | IP address to the WatchDog server |
+| `wd-host` | string (optional) | null | IP address to the WatchDog server |
 | `wd-port` | number (optional) | null | Port number to WatchDog server |
 | `wd-message` | string (optional) | 'ping' | Message that will be send thought the TCP socket connection to the WatchDog server |
 | `dp-validation` | array (optional) | null | Array of objects that contains the DP check validation |
@@ -57,7 +57,7 @@ Watchdog component can be used in the following way:
 <div id="app-isalive2" 
     name="test2" 
     interval="3000" 
-    wd-ip="127.0.0.1" 
+    wd-host="127.0.0.1" 
     wd-port="1234" 
     wd-message="Monitoring"
     dp-validation='[{"xid":"DP_EN1", "value":1, "check":"equal"}]' 
@@ -68,6 +68,6 @@ To embed this component in the page we need to add the new HTML component to our
 
 To create your own watchdog server you can use the following command:
 ```bash
-nc -4 -l 127.0.0.1 1234
+nc -4 -lk 127.0.0.1 1234
 ```
 When the component will check every step you should see the message received from the Scada client.

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -46,6 +46,8 @@ datapoint condition value.
 | `wd-port` | number (optional) | null | Port number to WatchDog server |
 | `wd-message` | string (optional) | 'ping' | Message that will be send thought the TCP socket connection to the WatchDog server |
 | `dp-validation` | array (optional) | null | Array of objects that contains the DP check validation |
+| `dp-break` | boolean (optional) | false | If that argument is set the 
+datapoint check will be break if the datapoint is not valid |
 | `dp-failure` | boolean | false | If that argument exists that means the DP check error will be treated as failure |
 
 
@@ -62,6 +64,7 @@ Watchdog component can be used in the following way:
     wd-message="Monitoring"
     dp-validation='[{"xid":"DP_EN1", "value":1, "check":"equal"}]' 
     dp-failure
+    dp-break
 ></div>
 ```
 To embed this component in the page we need to add the new HTML component to our view and then create a following div with "app-isalive2" id. Rest of the parameters are optional.

--- a/scadalts-ui/src/components/graphical_views/watchdog/README.md
+++ b/scadalts-ui/src/components/graphical_views/watchdog/README.md
@@ -46,8 +46,7 @@ datapoint condition value.
 | `wd-port` | number (optional) | null | Port number to WatchDog server |
 | `wd-message` | string (optional) | 'ping' | Message that will be send thought the TCP socket connection to the WatchDog server |
 | `dp-validation` | array (optional) | null | Array of objects that contains the DP check validation |
-| `dp-break` | boolean (optional) | false | If that argument is set the 
-datapoint check will be break if the datapoint is not valid |
+| `dp-break` | boolean (optional) | false | If that argument is set the datapoint check will be break if the datapoint is not valid |
 | `dp-failure` | boolean | false | If that argument exists that means the DP check error will be treated as failure |
 
 

--- a/scadalts-ui/src/components/graphical_views/watchdog/index.vue
+++ b/scadalts-ui/src/components/graphical_views/watchdog/index.vue
@@ -329,9 +329,11 @@ export default {
 		 */
 		checkPointCondition(datapoint, response) {
 			let respValue = null;
+			let checkValue = datapoint.value;
 			let binary = false;
 			if (response.type === 'BinaryValue') {
 				binary = true;
+				checkValue = Number(datapoint.value);
 				respValue = response.value == 'true' ? 1 : 0;
 			} else if (response.type === 'AlphanumericValue') {
 				respValue = response.value;
@@ -340,17 +342,17 @@ export default {
 			}
 
 			if (datapoint.check === 'equal') {
-				return datapoint.value === respValue;
+				return checkValue === respValue;
 			} else if (datapoint.check === 'not_equal') {
-				return datapoint.value !== respValue;
+				return checkValue !== respValue;
 			} else if (datapoint.check === 'greater' && !binary) {
-				return datapoint.value < respValue;
+				return checkValue < respValue;
 			} else if (datapoint.check === 'less' && !binary) {
-				return datapoint.value > respValue;
+				return checkValue > respValue;
 			} else if (datapoint.check === 'greater_equal' && !binary) {
-				return datapoint.value <= respValue;
+				return checkValue <= respValue;
 			} else if (datapoint.check === 'less_equal' && !binary) {
-				return datapoint.value >= respValue;
+				return checkValue >= respValue;
 			} else {
 				return false;
 			}

--- a/scadalts-ui/src/components/graphical_views/watchdog/index.vue
+++ b/scadalts-ui/src/components/graphical_views/watchdog/index.vue
@@ -192,6 +192,7 @@ export default {
 			try {
 				this.checkingConditions = true;
 				this.conditionsResult = [];
+				this.failedConditions = [];
 				this.isNetworkConnection();
 				await this.isServerConnection();
 				await this.areDataPointsValid();

--- a/scadalts-ui/src/components/graphical_views/watchdog/index.vue
+++ b/scadalts-ui/src/components/graphical_views/watchdog/index.vue
@@ -1,0 +1,380 @@
+<template>
+	<v-app>
+		<v-card elevation="1">
+			<v-card-text>
+				<v-row
+					v-if="!!lastMessage"
+					class="state-block"
+					v-bind:class="`is-state-${lastMessage.state.toLowerCase()}`"
+				>
+					<v-col xs="2" sm="1" class="flex-al-center" v-if="checkingConditions">
+						<v-icon class="is-loading">mdi-refresh</v-icon>
+					</v-col>
+					<v-col xs="2" sm="1" class="flex-al-center" v-else>
+						<v-icon v-if="lastMessage.state === 'OK'">mdi-check</v-icon>
+						<v-icon v-else-if="lastMessage.state === 'WARN'">mdi-alert</v-icon>
+						<v-icon v-else>mdi-close</v-icon>
+					</v-col>
+					<v-col cols="9" class="flex-al-center">
+						<v-row>
+							<v-col class="flex-al-center">
+								{{ lastMessage.message }}
+							</v-col>
+							<v-col xs="12" md="6" v-if="!!lastServerTime">
+								<p class="state-value-label">Last message</p>
+								{{ lastServerTime }}
+							</v-col>
+						</v-row>
+					</v-col>
+					<v-col cols="2" class="flex-al-center">
+						<v-menu offset-y offset-x left min-width="400">
+							<template v-slot:activator="{ on, attrs }">
+								<v-btn icon v-bind="attrs" v-on="on">
+									<v-icon>mdi-information-outline</v-icon>
+								</v-btn>
+							</template>
+							<v-card>
+								<v-card-title>
+									<span>
+										{{name}} 
+									</span>
+									<v-spacer>
+									</v-spacer>
+									<span>
+										{{clock}}
+									</span>
+									
+								</v-card-title>
+								<v-card-text>
+									<v-divider></v-divider>
+									<v-list>
+										<v-list-item
+											two-line
+											v-for="(i, index) in conditionsResult"
+											:key="index"
+										>
+											<v-list-item-icon>
+												<v-icon v-if="i.state === 'OK'">mdi-check</v-icon>
+												<v-icon v-else-if="i.state === 'WARN'">mdi-alert</v-icon>
+												<v-icon v-else>mdi-close</v-icon>
+											</v-list-item-icon>
+											<v-list-item-content>
+												<v-list-item-title>
+													{{ i.message }}
+												</v-list-item-title>
+												<v-list-item-subtitle v-if="!!i.description">
+													{{ i.description }}
+												</v-list-item-subtitle>
+											</v-list-item-content>
+										</v-list-item>
+									</v-list>
+								</v-card-text>
+							</v-card>
+						</v-menu>
+					</v-col>
+				</v-row>
+				<v-row v-if="!watchdogState.running">
+					<v-col cols="1"></v-col>
+					<v-col>
+						<p class="watchdog-note">
+							{{ $t(watchdogState.errorMessage) }}
+						</p>
+					</v-col>
+				</v-row>
+			</v-card-text>
+		</v-card>
+	</v-app>
+</template>
+<script>
+import Axios from 'axios';
+const WATCHDOG_API_TIME = './api/is_alive/time2';
+const WATCHDOG_API_RUNNER = './api/is_alive/watchdog';
+
+/**
+ * 
+ * Watchdog Component
+ * 
+ * @author radek2s <rjajko@softq.pl>
+ */
+export default {
+	props: {
+		name: {
+			type: String,
+			default: 'IsAlive2',
+		},
+		interval: {
+			type: Number,
+			default: 10000,
+		},
+		wdIp: {
+			type: String,
+			default: null,
+		},
+		wdPort: {
+			type: Number,
+			default: null,
+		},
+		dpValidation: {
+			type: Array,
+			default: null,
+		},
+		dpFailure: {
+			type: Boolean,
+			default: false,
+		},
+	},
+
+	data() {
+		return {
+			isAliveInterval: null,
+			networkConnection: false,
+			watchdogState: {
+				running: true,
+				errorMessage: '',
+			},
+			checkingConditions: false,
+			conditionsResult: [],
+			lastServerTime: null,
+			clock: null,
+			clockInterval: null,
+		};
+	},
+
+	computed: {
+		lastMessage() {
+			return this.conditionsResult.length > 0
+				? this.conditionsResult[this.conditionsResult.length - 1]
+				: null;
+		},
+	},
+
+	mounted() {
+		this.initNetworkMonitor();
+		this.isAlive();
+		this.initIsAliveLoop();
+		this.runClock();
+	},
+
+	destroyed() {
+		this.disableIsAliveLoop();
+		this.disableNetworkMonitor();
+		this.stopClock();
+	},
+
+	methods: {
+		//Main component loop//
+		initIsAliveLoop() {
+			if (!this.isAliveInterval) {
+				this.isAliveInterval = setInterval(() => {
+					this.isAlive();
+				}, this.interval);
+			}
+		},
+
+		disableIsAliveLoop() {
+			clearInterval(this.isAliveInterval);
+			this.isAliveInterval = null;
+		},
+
+		async isAlive() {
+			try {
+				this.checkingConditions = true;
+				this.conditionsResult = [];
+				this.isNetworkConnection();
+				await this.isServerConnection();
+				await this.areDataPointsValid();
+				await this.notifyWatchdog();
+			} catch (e) {
+				console.warn(e.message);
+			} finally {
+				this.checkingConditions = false;
+			}
+		},
+
+		// Validations and conditions //
+		isNetworkConnection() {
+			this.addConditionResult('Network connection', this.networkConnection);
+			if (!this.networkConnection) {
+				throw new Error('Network connection is not available');
+			}
+		},
+
+		async isServerConnection() {
+			try {
+				let resp = await Axios.get(WATCHDOG_API_TIME);
+				this.addConditionResult('Server connection', true);
+				this.lastServerTime = new Date(resp.data).toLocaleString();
+			} catch (error) {
+				this.addConditionResult('Unable to connect to Server', false, error.message);
+				throw new Error('Unable to connect to Server');
+			}
+		},
+
+		areDataPointsValid() {
+			if (!!this.dpValidation) {
+				let promiseArray = [];
+				this.dpValidation.forEach((p) => promiseArray.push(this.validateDataPoint(p)));
+				return Promise.all(promiseArray);
+			}
+			return Promise.resolve();
+		},
+
+		// NETWORK:: Network monitor methods //
+		initNetworkMonitor() {
+			this.networkConnection = navigator.onLine;
+			window.addEventListener('online', this.onNetworkStatusChange);
+			window.addEventListener('offline', this.onNetworkStatusChange);
+		},
+
+		disableNetworkMonitor() {
+			window.removeEventListener('online', this.onNetworkStatusChange);
+			window.removeEventListener('offline', this.onNetworkStatusChange);
+		},
+
+		onNetworkStatusChange() {
+			this.networkConnection = navigator.onLine;
+			this.isAlive();
+			if (this.networkConnection) {
+				this.initIsAliveLoop();
+			} else {
+				this.disableIsAliveLoop();
+			}
+		},
+
+		// DATAPOINTS:: DataPoint monitor methods //
+		async validateDataPoint(datapoint) {
+			try {
+				let resp = await Axios.get(`./api/point_value/getValue/${datapoint.xid}`);
+				if (this.checkPointCondition(datapoint, resp.data)) {
+					this.addConditionResult(`${resp.data.name} pass`, true);
+				} else {
+					this.addConditionResult(
+						`${resp.data.name} failed`,
+						this.dpFailure ? false : 'WARN',
+					);
+				}
+			} catch (error) {
+				this.addConditionResult(
+					`DataPoint ${datapoint.xid} fetching failed`,
+					false,
+					error.message,
+				);
+			}
+		},
+
+		async notifyWatchdog() {
+			if (!!this.wdIp && !!this.wdPort) {
+				try {
+					if (this.lastMessage.state !== 'FAILED') {
+						await Axios.post(WATCHDOG_API_RUNNER, {
+							address: this.wdIp,
+							port: this.wdPort,
+						});
+						this.watchdogState.running = true;
+						this.watchdogState.errorMessage = '';
+					}
+				} catch (error) {
+					this.watchdogState.running = false;
+					this.watchdogState.errorMessage = error.response.data;
+				}
+			}
+		},
+
+		addConditionResult(message, result, description = null) {
+			if (typeof result === 'boolean') {
+				result = result ? 'OK' : 'FAILED';
+			}
+			this.conditionsResult.push({
+				message: message,
+				state: result,
+				description: description,
+			});
+		},
+
+		runClock() {
+			if(!this.clockInterval) {
+				this.clockInterval = setInterval(() => {
+					this.clock = new Date().toLocaleString();
+				}, 1000);
+			}
+		},
+
+		stopClock() {
+			clearInterval(this.clockInterval);
+			this.clockInterval = null;
+		},
+
+		/**
+		 * Validate DataPoint condition
+		 *
+		 * @private
+		 */
+		checkPointCondition(datapoint, response) {
+			let respValue = null;
+			let binary = false;
+			if (response.type === 'BinaryValue') {
+				binary = true;
+				respValue = response.value == 'true';
+			} else if (response.type === 'AlphanumericValue') {
+				respValue = response.value;
+			} else {
+				respValue = Number(response.value);
+			}
+
+			if (datapoint.check === 'equal') {
+				return datapoint.value === respValue;
+			} else if (datapoint.check === 'not_equal') {
+				return datapoint.value !== respValue;
+			} else if (datapoint.check === 'greater' && !binary) {
+				return datapoint.value > respValue;
+			} else if (datapoint.check === 'less' && !binary) {
+				return datapoint.value < respValue;
+			} else if (datapoint.check === 'greater_equal' && !binary) {
+				return datapoint.value >= respValue;
+			} else if (datapoint.check === 'less_equal' && !binary) {
+				return datapoint.value <= respValue;
+			} else {
+				return false;
+			}
+		},
+	},
+};
+</script>
+<style>
+.flex-al-center {
+	display: flex;
+	align-items: center;
+}
+.is-loading {
+	animation: rotate 1s linear infinite;
+}
+.state-block {
+	border-radius: 5px;
+}
+.is-state-ok {
+	background-color: #98e171;
+}
+.is-state-warn {
+	background-color: #ffff74;
+}
+.is-state-failed {
+	background-color: #ff6f6a;
+}
+.state-value-label {
+	margin: -7px 0 !important;
+	font-size: 0.8em;
+	font-style: italic;
+}
+.watchdog-note {
+	margin: 0 !important;
+	font-style: italic;
+}
+@keyframes rotate {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+</style>

--- a/scadalts-ui/src/components/graphical_views/watchdog/index.vue
+++ b/scadalts-ui/src/components/graphical_views/watchdog/index.vue
@@ -113,6 +113,10 @@ export default {
 			type: Number,
 			default: null,
 		},
+		wdMessage: {
+			type: String,
+			default: null,
+		},
 		dpValidation: {
 			type: Array,
 			default: null,
@@ -268,6 +272,7 @@ export default {
 						await Axios.post(WATCHDOG_API_RUNNER, {
 							address: this.wdIp,
 							port: this.wdPort,
+							message: this.wdMessage || 'ping',
 						});
 						this.watchdogState.running = true;
 						this.watchdogState.errorMessage = '';

--- a/scadalts-ui/src/components/graphical_views/watchdog/index.vue
+++ b/scadalts-ui/src/components/graphical_views/watchdog/index.vue
@@ -325,13 +325,13 @@ export default {
 			} else if (datapoint.check === 'not_equal') {
 				return datapoint.value !== respValue;
 			} else if (datapoint.check === 'greater' && !binary) {
-				return datapoint.value > respValue;
-			} else if (datapoint.check === 'less' && !binary) {
 				return datapoint.value < respValue;
+			} else if (datapoint.check === 'less' && !binary) {
+				return datapoint.value > respValue;
 			} else if (datapoint.check === 'greater_equal' && !binary) {
-				return datapoint.value >= respValue;
-			} else if (datapoint.check === 'less_equal' && !binary) {
 				return datapoint.value <= respValue;
+			} else if (datapoint.check === 'less_equal' && !binary) {
+				return datapoint.value >= respValue;
 			} else {
 				return false;
 			}

--- a/scadalts-ui/src/components/graphical_views/watchdog/index.vue
+++ b/scadalts-ui/src/components/graphical_views/watchdog/index.vue
@@ -36,14 +36,12 @@
 							<v-card>
 								<v-card-title>
 									<span>
-										{{name}} 
+										{{ name }}
 									</span>
-									<v-spacer>
-									</v-spacer>
+									<v-spacer> </v-spacer>
 									<span>
-										{{clock}}
+										{{ clock }}
 									</span>
-									
 								</v-card-title>
 								<v-card-text>
 									<v-divider></v-divider>
@@ -91,10 +89,11 @@ const WATCHDOG_API_TIME = './api/is_alive/time2';
 const WATCHDOG_API_RUNNER = './api/is_alive/watchdog';
 
 /**
- * 
+ *
  * Watchdog Component
- * 
+ *
  * @author radek2s <rjajko@softq.pl>
+ * @version 1.0.01
  */
 export default {
 	props: {
@@ -292,7 +291,7 @@ export default {
 		},
 
 		runClock() {
-			if(!this.clockInterval) {
+			if (!this.clockInterval) {
 				this.clockInterval = setInterval(() => {
 					this.clock = new Date().toLocaleString();
 				}, 1000);

--- a/scadalts-ui/src/locales/en.json
+++ b/scadalts-ui/src/locales/en.json
@@ -441,5 +441,9 @@
 	"uiv.disable": "Disable",
 	"uiv.enable": "Enable",
 	"uiv.modal.cancel": "Cancel",
-	"uiv.modal.ok": "OK"
+	"uiv.modal.ok": "OK",
+	"watchdog.response.badRequest": "Check your request data!",
+	"watchdog.response.unauthorized": "You do not have permission to this action!",
+	"watchdog.response.unavailable": "Watchdog server is unreachable!",
+	"watchdog.response.unexpected": "Scada server error occurred!",
 }

--- a/scadalts-ui/src/locales/en.json
+++ b/scadalts-ui/src/locales/en.json
@@ -445,5 +445,5 @@
 	"watchdog.response.badRequest": "Check your request data!",
 	"watchdog.response.unauthorized": "You do not have permission to this action!",
 	"watchdog.response.unavailable": "Watchdog server is unreachable!",
-	"watchdog.response.unexpected": "Scada server error occurred!",
+	"watchdog.response.unexpected": "Scada server error occurred!"
 }

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -130,7 +130,7 @@ if (!!window.document.getElementById(watchdogId)) {
 				props: {
 					name: watchdogEl.getAttribute('name'),
 					interval: watchdogEl.getAttribute('interval') !== null ? Number(watchdogEl.getAttribute('interval')) : 10000,
-					wdIp: watchdogEl.getAttribute('wd-ip'),
+					wdHost: watchdogEl.getAttribute('wd-host'),
 					wdPort: watchdogEl.getAttribute('wd-port') !== null ? Number(watchdogEl.getAttribute('wd-port')) : null,
 					wdMessage: watchdogEl.getAttribute('wd-message'),
 					dpValidation: watchdogEl.getAttribute('dp-validation') !== null ? JSON.parse(watchdogEl.getAttribute('dp-validation')) : null,

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -132,6 +132,7 @@ if (!!window.document.getElementById(watchdogId)) {
 					interval: watchdogEl.getAttribute('interval') !== null ? Number(watchdogEl.getAttribute('interval')) : 10000,
 					wdIp: watchdogEl.getAttribute('wd-ip'),
 					wdPort: watchdogEl.getAttribute('wd-port') !== null ? Number(watchdogEl.getAttribute('wd-port')) : null,
+					wdMessage: watchdogEl.getAttribute('wd-message'),
 					dpValidation: watchdogEl.getAttribute('dp-validation') !== null ? JSON.parse(watchdogEl.getAttribute('dp-validation')) : null,
 					dpFailure: watchdogEl.getAttribute('dp-failure') !== null,
 				},

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -134,6 +134,7 @@ if (!!window.document.getElementById(watchdogId)) {
 					wdPort: watchdogEl.getAttribute('wd-port') !== null ? Number(watchdogEl.getAttribute('wd-port')) : null,
 					wdMessage: watchdogEl.getAttribute('wd-message'),
 					dpValidation: watchdogEl.getAttribute('dp-validation') !== null ? JSON.parse(watchdogEl.getAttribute('dp-validation')) : null,
+					dpBreak: watchdogEl.getAttribute('dp-break') !== null,
 					dpFailure: watchdogEl.getAttribute('dp-failure') !== null,
 				},
 			}),

--- a/scadalts-ui/src/main.js
+++ b/scadalts-ui/src/main.js
@@ -11,6 +11,7 @@ import VueDayjs from 'vue-dayjs-plugin';
 
 import Test from './components/Test';
 import IsAlive from './components/graphical_views/IsAlive';
+import Watchdog from './components/graphical_views/watchdog';
 import CMP from './components/graphical_views/cmp/CMP';
 import AutoManual from './components/graphical_views/cmp2/AutoManual'
 import SimpleComponentSVG from './components/graphical_views/SimpleComponentSVG';
@@ -117,6 +118,27 @@ if (window.document.getElementById('app-isalive') != undefined) {
 	}).$mount('#app-isalive');
 }
 
+const watchdogId = "app-isalive2";
+if (!!window.document.getElementById(watchdogId)) {
+	const watchdogEl = document.getElementById(watchdogId);
+	new Vue({
+		store,
+		i18n,
+		vuetify,
+		render: (h) =>
+			h(Watchdog, {
+				props: {
+					name: watchdogEl.getAttribute('name'),
+					interval: watchdogEl.getAttribute('interval') !== null ? Number(watchdogEl.getAttribute('interval')) : 10000,
+					wdIp: watchdogEl.getAttribute('wd-ip'),
+					wdPort: watchdogEl.getAttribute('wd-port') !== null ? Number(watchdogEl.getAttribute('wd-port')) : null,
+					dpValidation: watchdogEl.getAttribute('dp-validation') !== null ? JSON.parse(watchdogEl.getAttribute('dp-validation')) : null,
+					dpFailure: watchdogEl.getAttribute('dp-failure') !== null,
+				},
+			}),
+	}).$mount(`#${watchdogId}`);
+}
+
 for (let i = 0; i < 20; i++) {
 	const cmpId = `app-cmp-${i}`;
 	if (window.document.getElementById(cmpId) != undefined) {
@@ -153,15 +175,15 @@ for (let i = 0; i < 10; i++) {
 					props: {
 						pConfig: JSON.parse(el.getAttribute('pconfig')),
 						pLabel: el.getAttribute('plabel'),
-						pTimeRefresh: el.getAttribute('ptimeRefresh') !== null  ? el.getAttribute('ptimeRefresh') : 10000,
+						pTimeRefresh: el.getAttribute('ptimeRefresh') !== null ? el.getAttribute('ptimeRefresh') : 10000,
 						pxIdViewAndIdCmp: el.getAttribute('pxIdViewAndIdCmp'),
 						pZeroState: el.getAttribute('pzeroState') !== null ? el.getAttribute('pzeroState') : 'Auto',
-						pWidth: el.getAttribute('pwidth') !== null  ? el.getAttribute('pwidth') : 140,
+						pWidth: el.getAttribute('pwidth') !== null ? el.getAttribute('pwidth') : 140,
 						pRequestTimeout: el.getAttribute('prequestTimeout') !== null ? el.getAttribute('prequestTimeout') : 5000,
 						pHideControls: el.getAttribute('phideControls') !== null,
 						pDebugRequest: el.getAttribute('pdebugRequest') !== null,
 					},
-				})			
+				})
 		}).$mount('#' + cmpId);
 	}
 }

--- a/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
+++ b/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
@@ -1,0 +1,198 @@
+import { expect } from 'chai';
+import { prepareMountWrapper } from "../../utils/testing-utils";
+
+import Watchdog from "@/components/graphical_views/watchdog";
+
+const modules = {};
+
+global.requestAnimationFrame = (cb) => cb();
+global.cancelAnimationFrame = window.clearTimeout;
+
+describe('💠️ Watchdog Unit Basic Test Scenario', () => {
+    let wrapper;
+
+    before(() => {
+        wrapper = prepareMountWrapper(Watchdog, modules);
+    })
+
+    describe('Component Default Initialization', () => {
+
+        it('Is component prop interval initialized', async () => {
+            await wrapper.vm.$nextTick();
+            expect(wrapper.vm.interval).to.equal(10000);
+        })
+
+        it('Is component prop wdIp is by default equal to null', () => {
+            expect(wrapper.vm.wdIp).to.equal(null);
+        })
+
+        it('Is component prop wdPort is by default equal to null', () => {
+            expect(wrapper.vm.wdPort).to.equal(null);
+        })
+
+        it('Is component prop dpValidation is by default equal to null', () => {
+            expect(wrapper.vm.dpValidation).to.equal(null);
+        })
+
+        it('Is component prop dpFailure is by default equal to false', () => {
+            expect(wrapper.vm.dpFailure).to.equal(false);
+        })
+
+        it('Is Alive Interval running', async () => {
+            await wrapper.vm.$nextTick();
+            expect(wrapper.vm.isAliveInterval).to.not.equal(null);
+        })
+    })
+})
+
+describe('💠️ Watchdog Unit Props Test Scenario', () => {
+    let wrapper;
+
+    before(() => {
+        wrapper = prepareMountWrapper(Watchdog, modules, {
+            name: 'MochaTests',
+            interval: 5000,
+            wdIp: '127.0.0.1',
+            wdPort: 1234,
+            dpValidation: [{
+                xid: 'DP_TEST',
+                value: 1,
+                check: 'equal',
+            }],
+        });
+    })
+
+    describe('Component Default Initialization', () => {
+
+        it('Is component prop interval initialized', async () => {
+            await wrapper.vm.$nextTick();
+            expect(wrapper.vm.interval).to.equal(5000);
+        })
+
+        it('Is component prop wdIp is equal to "127.0.0.1"', () => {
+            expect(wrapper.vm.wdIp).to.equal('127.0.0.1');
+        })
+
+        it('Is component prop wdPort is equal to 1234', () => {
+            expect(wrapper.vm.wdPort).to.equal(1234);
+        })
+
+        it('Is component prop dpValidation xid is equal to object config', () => {
+            expect(wrapper.vm.dpValidation[0].xid).to.equal("DP_TEST");
+        })
+
+        it('Is component prop dpFailure is by default equal to false', () => {
+            expect(wrapper.vm.dpFailure).to.equal(false);
+        })
+
+        it('Is Network connection OK', async () => {
+            await wrapper.vm.$nextTick();
+            expect(wrapper.vm.lastMessage.message).to.equal("Network connection");
+            expect(wrapper.vm.lastMessage.state).to.equal("OK");
+        });
+
+        it('Is component checking conditions', () => {
+            expect(wrapper.vm.checkingConditions).to.equal(true);
+        })
+
+    })
+})
+
+
+describe('💠️ Watchdog Methods Unit Test Scenario', () => {
+    let wrapper;
+
+    before(() => {
+        wrapper = prepareMountWrapper(Watchdog, modules);
+    })
+
+    describe('Check Point Condition Tests', () => {
+
+        it('Binary DP value true, check "equal true" should be true', () => {
+            const dp = {
+                check: 'equal',
+                value: true,
+            }
+            const response = {
+                type: 'BinaryValue',
+                value: 'true',
+            }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
+        it('Binary DP value "false", check "equal true" should be false', () => {
+            const dp = {
+                check: 'equal',
+                value: true,
+            }
+            const response = {
+                type: 'BinaryValue',
+                value: 'false',
+            }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Binary DP value "true", check "not_equal true" should be false', () => {
+            const dp = { check: 'not_equal', value: true }
+            const response = { type: 'BinaryValue', value: 'true' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Binary DP value "true", check "greater true" should be false', () => {
+            const dp = { check: 'greater', value: true }
+            const response = { type: 'BinaryValue', value: 'true' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Binary DP value "true", check "less true" should be false', () => {
+            const dp = { check: 'less', value: true }
+            const response = { type: 'BinaryValue', value: 'true' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Numeric DP value "1.0", check "equal 1" should be true', () => {
+            const dp = { check: 'equal', value: 1 }
+            const response = { type: 'NumericValue', value: '1.0' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
+        it('Numeric DP value "1.5", check "equal 1" should be false', () => {
+            const dp = { check: 'equal', value: 1 }
+            const response = { type: 'NumericValue', value: '1.5' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Numeric DP value "1.5", check "not_equal 1" should be true', () => {
+            const dp = { check: 'not_equal', value: 1 }
+            const response = { type: 'NumericValue', value: '1.5' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
+        it('Numeric DP value "1.5", check "greater 1" should be true', () => {
+            const dp = { check: 'greater', value: 1 }
+            const response = { type: 'NumericValue', value: '1.5' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
+        it('Numeric DP value "1.5", check "less 1" should be false', () => {
+            const dp = { check: 'less', value: 1 }
+            const response = { type: 'NumericValue', value: '1.5' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Numeric DP value "1.5", check "less 1.5" should be false', () => {
+            const dp = { check: 'less', value: 1.5 }
+            const response = { type: 'NumericValue', value: '1.5' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Numeric DP value "1.5", check "less_equal 1.5" should be true', () => {
+            const dp = { check: 'less_equal', value: 1.5 }
+            const response = { type: 'NumericValue', value: '1.5' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
+        
+
+    })
+})

--- a/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
+++ b/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
@@ -23,7 +23,7 @@ describe('💠️ Watchdog Unit Basic Test Scenario', () => {
         })
 
         it('Is component prop wdIp is by default equal to null', () => {
-            expect(wrapper.vm.wdIp).to.equal(null);
+            expect(wrapper.vm.wdHost).to.equal(null);
         })
 
         it('Is component prop wdPort is by default equal to null', () => {
@@ -52,7 +52,7 @@ describe('💠️ Watchdog Unit Props Test Scenario', () => {
         wrapper = prepareMountWrapper(Watchdog, modules, {
             name: 'MochaTests',
             interval: 5000,
-            wdIp: '127.0.0.1',
+            wdHost: '127.0.0.1',
             wdPort: 1234,
             dpValidation: [{
                 xid: 'DP_TEST',
@@ -70,7 +70,7 @@ describe('💠️ Watchdog Unit Props Test Scenario', () => {
         })
 
         it('Is component prop wdIp is equal to "127.0.0.1"', () => {
-            expect(wrapper.vm.wdIp).to.equal('127.0.0.1');
+            expect(wrapper.vm.wdHost).to.equal('127.0.0.1');
         })
 
         it('Is component prop wdPort is equal to 1234', () => {
@@ -98,10 +98,10 @@ describe('💠️ Watchdog Methods Unit Test Scenario', () => {
 
     describe('Check Point Condition Tests', () => {
 
-        it('Binary DP value true, check "equal true" should be true', () => {
+        it('Binary DP value true, check "equal 1" should be true', () => {
             const dp = {
                 check: 'equal',
-                value: true,
+                value: 1,
             }
             const response = {
                 type: 'BinaryValue',
@@ -110,10 +110,10 @@ describe('💠️ Watchdog Methods Unit Test Scenario', () => {
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
         })
 
-        it('Binary DP value "false", check "equal true" should be false', () => {
+        it('Binary DP value "false", check "equal 1" should be false', () => {
             const dp = {
                 check: 'equal',
-                value: true,
+                value: 1,
             }
             const response = {
                 type: 'BinaryValue',
@@ -122,20 +122,20 @@ describe('💠️ Watchdog Methods Unit Test Scenario', () => {
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })
 
-        it('Binary DP value "true", check "not_equal true" should be false', () => {
-            const dp = { check: 'not_equal', value: true }
+        it('Binary DP value "true", check "not_equal 1" should be false', () => {
+            const dp = { check: 'not_equal', value: 1 }
             const response = { type: 'BinaryValue', value: 'true' }
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })
 
-        it('Binary DP value "true", check "greater true" should be false', () => {
-            const dp = { check: 'greater', value: true }
+        it('Binary DP value "true", check "greater 1" should be false', () => {
+            const dp = { check: 'greater', value: 1 }
             const response = { type: 'BinaryValue', value: 'true' }
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })
 
-        it('Binary DP value "true", check "less true" should be false', () => {
-            const dp = { check: 'less', value: true }
+        it('Binary DP value "true", check "less 1" should be false', () => {
+            const dp = { check: 'less', value: 1 }
             const response = { type: 'BinaryValue', value: 'true' }
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })

--- a/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
+++ b/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
@@ -110,6 +110,12 @@ describe('💠️ Watchdog Methods Unit Test Scenario', () => {
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
         })
 
+        it('Binary DP value true, check "equal true" should be true', () => {
+            const dp = { check: 'equal', value: true }
+            const response = { type: 'BinaryValue', value: 'true' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
         it('Binary DP value "false", check "equal 1" should be false', () => {
             const dp = {
                 check: 'equal',
@@ -122,8 +128,20 @@ describe('💠️ Watchdog Methods Unit Test Scenario', () => {
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })
 
+        it('Binary DP value "false", check "equal true" should be false', () => {
+            const dp = { check: 'equal', value: true }
+            const response = { type: 'BinaryValue', value: 'false' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
         it('Binary DP value "true", check "not_equal 1" should be false', () => {
             const dp = { check: 'not_equal', value: 1 }
+            const response = { type: 'BinaryValue', value: 'true' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
+        })
+
+        it('Binary DP value "true", check "not_equal true" should be false', () => {
+            const dp = { check: 'not_equal', value: true }
             const response = { type: 'BinaryValue', value: 'true' }
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })
@@ -144,6 +162,12 @@ describe('💠️ Watchdog Methods Unit Test Scenario', () => {
             const dp = { check: 'equal', value: 1 }
             const response = { type: 'NumericValue', value: '1.0' }
             expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(true);
+        })
+
+        it('Numeric DP value "1.0", check "equal true" should be false', () => {
+            const dp = { check: 'equal', value: true }
+            const response = { type: 'NumericValue', value: '1.0' }
+            expect(wrapper.vm.checkPointCondition(dp, response)).to.equal(false);
         })
 
         it('Numeric DP value "1.5", check "equal 1" should be false', () => {

--- a/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
+++ b/scadalts-ui/tests/unit/WatchDogComponent/IsAlive2.spec.js
@@ -85,16 +85,6 @@ describe('💠️ Watchdog Unit Props Test Scenario', () => {
             expect(wrapper.vm.dpFailure).to.equal(false);
         })
 
-        it('Is Network connection OK', async () => {
-            await wrapper.vm.$nextTick();
-            expect(wrapper.vm.lastMessage.message).to.equal("Network connection");
-            expect(wrapper.vm.lastMessage.state).to.equal("OK");
-        });
-
-        it('Is component checking conditions', () => {
-            expect(wrapper.vm.checkingConditions).to.equal(true);
-        })
-
     })
 })
 

--- a/src/org/scada_lts/web/mvc/api/components/is_alive/TimeFromServer.java
+++ b/src/org/scada_lts/web/mvc/api/components/is_alive/TimeFromServer.java
@@ -7,14 +7,16 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
 import java.time.Instant;
-import java.util.Date;
 import java.util.Optional;
 
 /**
@@ -90,13 +92,13 @@ public class TimeFromServer {
     }
 
     private void sendWatchdogMessage(WatchDogConfig config, HttpServletRequest request) throws IOException {
-        Socket socket = new Socket(config.getHost(), config.getPort());
-        DataOutputStream messageStream = new DataOutputStream(socket.getOutputStream());
-        String remoteAddress = Optional.ofNullable(request.getHeader("X-FORWARDED-FOR"))
-                .orElse(request.getRemoteAddr()) ;
-        messageStream.writeBytes(remoteAddress + "|" + config.getMessage());
-        socket.close();
-        messageStream.close();
+        try(Socket socket = new Socket(config.getHost(), config.getPort())) {
+            try(DataOutputStream messageStream = new DataOutputStream(socket.getOutputStream())) {
+                String remoteAddress = Optional.ofNullable(request.getHeader("X-FORWARDED-FOR"))
+                        .orElse(request.getRemoteAddr()) ;
+                messageStream.writeBytes(remoteAddress + "|" + config.getMessage());
+            }
+        }
     }
 }
 

--- a/src/org/scada_lts/web/mvc/api/components/is_alive/TimeFromServer.java
+++ b/src/org/scada_lts/web/mvc/api/components/is_alive/TimeFromServer.java
@@ -7,21 +7,25 @@ import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
 import java.time.Instant;
+import java.util.Date;
 
 /**
  * @autor grzegorz.bylica@gmail.com on 24.09.2019
  */
 @Controller
+@RequestMapping(value = "/api/is_alive")
 public class TimeFromServer {
 
     private static final Log LOG = LogFactory.getLog(TimeFromServer.class);
 
-    @RequestMapping(value = "/api/is_alive/time", method = RequestMethod.GET)
+    @GetMapping(value = "/time")
     public ResponseEntity<Long> time(HttpServletRequest request) {
         LOG.info("/api/is_alive/time");
 
@@ -41,5 +45,70 @@ public class TimeFromServer {
             }
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
+    }
+
+    @GetMapping(value = "/time2")
+    public ResponseEntity<Long> getServerTime(HttpServletRequest request) {
+        LOG.info("/api/is_alive/time2");
+        try {
+            User user = Common.getUser(request);
+            if (user != null) {
+                long unixTimestamp = System.currentTimeMillis();
+                return new ResponseEntity<>(unixTimestamp, HttpStatus.OK);
+            }
+            return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    @PostMapping(value = "/watchdog")
+    public ResponseEntity<String> notifyWatchdog(@RequestBody WatchDogConfig config, HttpServletRequest request) {
+        String rootKey = "watchdog.response";
+        try {
+            User user = Common.getUser(request);
+            if(config == null) { return new ResponseEntity<>(rootKey + ".badRequest", HttpStatus.BAD_REQUEST); }
+            if(user == null) { return new ResponseEntity<>(rootKey + ".unauthorized", HttpStatus.UNAUTHORIZED); }
+            sendWatchdogMessage(config);
+            return new ResponseEntity<>(HttpStatus.OK);
+        } catch (IOException e) {
+            LOG.warn(e.getMessage());
+            return new ResponseEntity<>(rootKey + ".unavailable", HttpStatus.SERVICE_UNAVAILABLE);
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+            return new ResponseEntity<>(rootKey + ".unexpected",HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void sendWatchdogMessage(WatchDogConfig config) throws IOException {
+        Socket socket = new Socket(config.getHost(), config.getPort());
+        DataOutputStream messageStream = new DataOutputStream(socket.getOutputStream());
+        messageStream.writeBytes("ping");
+        socket.close();
+        messageStream.close();
+    }
+}
+
+class WatchDogConfig {
+    private String host;
+    private int port;
+
+    public WatchDogConfig() {
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
     }
 }


### PR DESCRIPTION
Base on the issue #2051 that was request by one of our customers we provide a new Vue.js component that is responsible for checking the Scada-LTS health and if everything is ok this component should send a heartbeat tick to the WatchDog server. Now this component is checking the network connectivity and the application response. User can extend the behaviour of that component by adding additional conditions that should be check to inform user about the application state. 

![image](https://user-images.githubusercontent.com/22638815/151125940-504bad2c-e032-459f-bb74-c49edfa2405d.png)

Using info button user can check which validation step caused error. 

### Configuration: 
Details how to configure that component can be found [here](https://github.com/SCADA-LTS/Scada-LTS/tree/feature/%232051_is_alive2/scadalts-ui/src/components/graphical_views/watchdog) in the component documentation.
