### PR TITLE
Fix docker-hub tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,12 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Login again to Docker Hub
+        if: ${{ startsWith(github.base_ref, 'release') || startsWith(github.base_ref, 'preview') }}
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push nightly Docker image
         if: ${{ startsWith(github.base_ref, 'release') || startsWith(github.base_ref, 'preview') }}
         uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,3 +168,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push nightly Docker image
+        if: ${{ startsWith(github.base_ref, 'refs/head/release') || startsWith(github.base_ref, 'refs/head/preview') }}
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: nightly
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,7 +169,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Build and push nightly Docker image
-        if: ${{ startsWith(github.base_ref, 'refs/head/release') || startsWith(github.base_ref, 'refs/head/preview') }}
+        if: ${{ startsWith(github.base_ref, 'release') || startsWith(github.base_ref, 'preview') }}
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,17 +168,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: Login again to Docker Hub
-        if: ${{ startsWith(github.base_ref, 'release') || startsWith(github.base_ref, 'preview') }}
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build and push nightly Docker image
         if: ${{ startsWith(github.base_ref, 'release') || startsWith(github.base_ref, 'preview') }}
         uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: nightly
+          tags: scadalts/scadalts:nightly
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
After merging this pull request we will provide the following DockerHub organization:

`master` - This tag will be updated every time we merge our code with the master branch
`latest` - This tag will be updated every time we publish a new release. So if user want to be up to date we suggest to use this tag.
`develop` - This tag will be updated every time we merge our code with the develop branch
`nightly` - This is a new tag that will be updated every time we provide a new functionality to our 'pre-release' branch. So this tag can be treated as the beta-channel that will contain updates from our latest works. But keep in mind that sometimes we will update the patch number from the previous minor Scada-LTS version so  it may override the docker image.
