### PR TITLE
Fix #2095 typo in class name view edit controller

### DIFF
--- a/src/org/scada_lts/web/mvc/controller/ViewEditController.java
+++ b/src/org/scada_lts/web/mvc/controller/ViewEditController.java
@@ -50,8 +50,8 @@ import com.serotonin.mango.vo.permission.Permissions;
 
 
 @Controller
-public class ViewEditContorller {
-    private static final Log LOG = LogFactory.getLog(ViewEditContorller.class);
+public class ViewEditController {
+    private static final Log LOG = LogFactory.getLog(ViewEditController.class);
     
     private static final String SUBMIT_UPLOAD = "upload";
     private static final String SUBMIT_CLEAR_IMAGE = "clearImage";


### PR DESCRIPTION
This PR is fixing issue #2095.
This class is not used anywhere else, so renaming it, shouldn't break anything.