### PR TITLE
#1088 ConcurrentModificationException in ContentGenerator.generateCon…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,5 +170,6 @@ test {
         includeTestsMatching "org.scada_lts.utils.UploadFileUtilsTestsSuite"
         includeTestsMatching "org.scada_lts.utils.xml.XmlSecurityTestsSuite"
         includeTestsMatching "org.scada_lts.utils.SystemSettingsUtilsTest"
+        includeTestsMatching "br.org.scadabr.view.component.GenerateAlarmListComponentTest"
     }
 }

--- a/build.xml
+++ b/build.xml
@@ -28,7 +28,11 @@
 		<pathelement location="${env.CATALINA_HOME}/lib/catalina-ant.jar"/>
 	</path>
 
-	<target name="init-core" description="Prepare project before build">
+	<target name="clear" >
+		<delete dir="${web.classes.dir}"/>
+	</target>
+
+	<target name="init-core" description="Prepare project before build" depends="clear">
 		<delete dir="${build-project.dir}"/>
 		<mkdir dir="${build-project.dir}"/>
 		<mkdir dir="${build-project.src.dir}"/>
@@ -283,6 +287,10 @@
 			</test>
 
 			<test name="org.scada_lts.utils.SystemSettingsUtilsTest"
+				  haltonfailure="yes">
+			</test>
+
+			<test name="br.org.scadabr.view.component.GenerateAlarmListComponentTest"
 				  haltonfailure="yes">
 			</test>
 		</junit>

--- a/src/br/org/scadabr/view/component/AlarmListComponent.java
+++ b/src/br/org/scadabr/view/component/AlarmListComponent.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -54,7 +55,7 @@ public class AlarmListComponent extends CustomComponent {
 		int max = events.size() > maxListSize ? maxListSize : events.size();
 
 		model.put("nome", "marlon");
-		model.put("events", events.subList(0, max));
+		model.put("events", new CopyOnWriteArrayList<>(events.subList(0, max)));
 		model.put("width", width > 0 ? width : 500);
 		model.put("hideIdColumn", hideIdColumn);
 		model.put("hideAlarmLevelColumn", hideAlarmLevelColumn);

--- a/test/br/org/scadabr/view/component/GenerateAlarmListComponentTest.java
+++ b/test/br/org/scadabr/view/component/GenerateAlarmListComponentTest.java
@@ -1,0 +1,94 @@
+package br.org.scadabr.view.component;
+
+import com.serotonin.mango.Common;
+import com.serotonin.mango.db.dao.EventDao;
+import com.serotonin.mango.rt.event.EventInstance;
+import com.serotonin.mango.vo.User;
+import com.serotonin.mango.web.dwr.BaseDwr;
+import com.serotonin.timer.RealTimeTimer;
+import org.apache.commons.logging.LogFactory;
+import org.directwebremoting.WebContext;
+import org.directwebremoting.WebContextFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.scada_lts.mango.service.EventService;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({BaseDwr.class, WebContextFactory.class, Common.class,
+        AlarmListComponent.class, LogFactory.class, EventService.class,
+        EventDao.class})
+public class GenerateAlarmListComponentTest {
+
+    private final static String CONTENT_EXPECTED = "test";
+    private AlarmListComponent subject;
+
+    @Mock
+    private WebContext webContext;
+
+    private EventService eventService;
+
+    @Mock
+    private User user;
+
+    @Before
+    public void setup() throws Exception {
+
+        mockStatic(WebContextFactory.class);
+        mockStatic(BaseDwr.class);
+        mockStatic(LogFactory.class);
+
+        RealTimeTimer realTimeTimerMock = PowerMockito.mock(RealTimeTimer.class);
+        whenNew(RealTimeTimer.class).withNoArguments().thenReturn(realTimeTimerMock);
+        mockStatic(Common.class);
+
+        when(WebContextFactory.get()).thenReturn(webContext);
+        when(Common.getUser()).thenReturn(user);
+
+        eventService = PowerMockito.mock(EventService.class);
+        whenNew(EventService.class).withNoArguments().thenReturn(eventService);
+
+        subject = new AlarmListComponent();
+    }
+
+    @Test
+    public void when_generateContent_with_eventsSubList_after_modifying_events_and_invoke_size_on_eventsSubList_then_not_throw_ConcurrentModificationException() throws Exception {
+
+        //given:
+        CopyOnWriteArrayList<EventInstance> events = new CopyOnWriteArrayList<>();
+        when(eventService.getPendingEvents(anyInt())).thenReturn(events);
+
+        HashMap<String, Object> model = new HashMap<>();
+        whenNew(HashMap.class).withNoArguments().thenReturn(model);
+
+        when(BaseDwr.generateContent(any(), any(), eq(model)))
+                .thenAnswer(invocation -> {
+                    Map<String, Object> modelArgs = (Map<String, Object>)invocation.getArguments()[2];
+                    List<String> eventsSubList = (List<String>)modelArgs.get("events");
+                    events.add(null);
+                    eventsSubList.size();
+                    return CONTENT_EXPECTED;
+                });
+
+        //when:
+        String result = subject.generateContent();
+
+        //then:
+        assertEquals(CONTENT_EXPECTED, result);
+    }
+
+}


### PR DESCRIPTION
…tent - added test: GenerateAlarmListComponentTest; corrected AlarmListComponent.generateContent: new instance of the event list is set in the model; added clear task in build.xml