### PR TITLE
#2261 Corrected schema version in web.xml - up schema version from 3.…

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
-         http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+         http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
          version="3.1">
 
   <!-- Is not use Kamil Jarmusik 2021/12/01-->


### PR DESCRIPTION
…0 to 3.1; corrected namespace http://java.sun.com/xml/ns/javaee (max version 3.0, Java EE 6.0) on http://xmlns.jcp.org/xml/ns/javaee (min version 3.1, Java EE 7.0)