### PR TITLE
#2436 BeanFactory not initialized or already closed - initialize cont…

### DIFF
--- a/WebContent/WEB-INF/applicationContext.xml
+++ b/WebContent/WEB-INF/applicationContext.xml
@@ -18,17 +18,11 @@
     along with this program.  If not, see http://www.gnu.org/licenses/.
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:cache="http://www.springframework.org/schema/cache"
        xsi:schemaLocation="
         http://www.springframework.org/schema/beans     
         http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
-        http://www.springframework.org/schema/context
-        http://www.springframework.org/schema/context/spring-context-4.2.xsd
-        http://www.springframework.org/schema/mvc
-        http://www.springframework.org/schema/mvc/spring-mvc-4.2.xsd
         http://www.springframework.org/schema/cache
         http://www.springframework.org/schema/cache/spring-cache.xsd
 ">
@@ -173,7 +167,7 @@
     <constructor-arg ref="resetHighestAlarmLevelJob"/>
   </bean>
 
-  <bean id="highestAlarmLevelServiceWithCache" class="org.scada_lts.service.HighestAlarmLevelServiceWithCache" lazy-init="true">
+  <bean id="highestAlarmLevelServiceWithCache" class="org.scada_lts.service.HighestAlarmLevelServiceWithCache">
     <constructor-arg ref="highestAlarmLevelCache"/>
     <constructor-arg ref="highestAlarmLevelDAO"/>
     <constructor-arg ref="resetHighestAlarmLevelScheduler"/>
@@ -221,4 +215,11 @@
     <constructor-arg ref="userCommentDaoWithCache"/>
   </bean>
   <!-- -->
+
+  <bean id="databaseSource" class="org.springframework.jndi.JndiObjectFactoryBean">
+    <property name="expectedType" value="javax.sql.DataSource"/>
+    <property name="jndiName" value="java:comp/env/jdbc/scadalts"/>
+  </bean>
+
+  <bean id="mangoContextListener" class="com.serotonin.mango.MangoContextListener" />
 </beans>

--- a/WebContent/WEB-INF/spring-security.xml
+++ b/WebContent/WEB-INF/spring-security.xml
@@ -173,7 +173,7 @@
     <authentication-manager id="authenticationManager">
         <authentication-provider>
             <password-encoder ref="scadaPasswordEncoder" />
-            <jdbc-user-service id="jdbcUserService" data-source-ref="dataSourceForSecurity"
+            <jdbc-user-service id="jdbcUserService" data-source-ref="databaseSource"
                                users-by-username-query="SELECT username, password, disabled = 'N' AS enabled FROM users WHERE username = ?"
                                authorities-by-username-query="SELECT username,
                                CASE WHEN admin = 'Y' THEN 'ROLE_ADMIN'
@@ -184,11 +184,6 @@
     </authentication-manager>
 
     <b:bean id="loginAuthenticationSuccessHandler" class="org.scada_lts.login.LoginAuthenticationSuccessHandler" />
-
-    <b:bean id="dataSourceForSecurity" class="org.springframework.jndi.JndiObjectFactoryBean">
-        <b:property name="expectedType" value="javax.sql.DataSource"/>
-        <b:property name="jndiName" value="java:comp/env/jdbc/scadalts"/>
-    </b:bean>
 
     <b:bean id="scadaPasswordEncoder" class="org.scada_lts.login.CustomPasswordEncoder" />
 
@@ -236,4 +231,6 @@
     <b:bean id="basicAuthenticationEntryPoint" class="org.springframework.security.web.authentication.www.BasicAuthenticationEntryPoint">
         <b:property name="realmName" value="Basic Auth"/>
     </b:bean>
+
+    <b:bean id="GetSecurityBeans" class="org.scada_lts.web.beans.GetSecurityBeans"/>
 </b:beans>

--- a/WebContent/WEB-INF/springDispatcher-servlet.xml
+++ b/WebContent/WEB-INF/springDispatcher-servlet.xml
@@ -2,19 +2,13 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:mvc="http://www.springframework.org/schema/mvc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:websocket="http://www.springframework.org/schema/websocket"
-       xmlns:security="http://www.springframework.org/schema/security"
 	xsi:schemaLocation="
         http://www.springframework.org/schema/beans     
         http://www.springframework.org/schema/beans/spring-beans-4.2.xsd
         http://www.springframework.org/schema/context 
         http://www.springframework.org/schema/context/spring-context-4.2.xsd
         http://www.springframework.org/schema/mvc
-        http://www.springframework.org/schema/mvc/spring-mvc-4.2.xsd
-        http://www.springframework.org/schema/websocket
-        http://www.springframework.org/schema/websocket/spring-websocket-4.2.xsd
-        http://www.springframework.org/schema/security
-        https://www.springframework.org/schema/security/spring-security-4.2.xsd">
+        http://www.springframework.org/schema/mvc/spring-mvc-4.2.xsd">
 
 	<context:component-scan base-package="org.scada_lts" />
     <mvc:annotation-driven />

--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -387,9 +387,6 @@
     <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
   </listener>
   <listener>
-    <listener-class>com.serotonin.mango.MangoContextListener</listener-class>
-  </listener>
-  <listener>
     <listener-class>org.springframework.security.web.session.HttpSessionEventPublisher</listener-class>
   </listener>
   <session-config>

--- a/src/com/serotonin/mango/MangoContextListener.java
+++ b/src/com/serotonin/mango/MangoContextListener.java
@@ -66,6 +66,9 @@ import org.scada_lts.config.ScadaVersion;
 import org.scada_lts.dao.SystemSettingsDAO;
 import org.scada_lts.mango.adapter.MangoScadaConfig;
 import org.scada_lts.scripting.SandboxContextFactory;
+import org.scada_lts.service.HighestAlarmLevelServiceWithCache;
+import org.scada_lts.service.IHighestAlarmLevelService;
+import org.scada_lts.web.beans.ApplicationBeans;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
@@ -105,6 +108,7 @@ public class MangoContextListener implements ServletContextListener {
 		freemarkerInitialize(ctx);
 		imageSetInitialize(ctx);
 		databaseInitialize(ctx);
+		highestAlarmLevelServiceInitialize();
 		dataPointsNameToIdMapping(ctx);
 
 		// Check if the known servlet context path has changed.
@@ -617,4 +621,16 @@ public class MangoContextListener implements ServletContextListener {
 
 		// MemoryCheck.start();
 	}
+
+	private void highestAlarmLevelServiceInitialize() {
+		try {
+			IHighestAlarmLevelService highestAlarmLevelService = ApplicationBeans.getHighestAlarmLevelServiceBean();
+			if(highestAlarmLevelService instanceof HighestAlarmLevelServiceWithCache) {
+				((HighestAlarmLevelServiceWithCache)highestAlarmLevelService).init();
+			}
+		} catch (Exception e) {
+			log.error(e);
+		}
+	}
+
 }

--- a/src/com/serotonin/mango/vo/User.java
+++ b/src/com/serotonin/mango/vo/User.java
@@ -232,24 +232,26 @@ public class User implements SetPointSource, HttpSessionBindingListener,
 	// / HttpSessionBindingListener implementation
 	// /
 	//
+	@Deprecated
 	public void valueBound(HttpSessionBindingEvent evt) {
 		// User is bound to a session when logged in. Notify the event manager.
-		SystemEventType.raiseEvent(new SystemEventType(
+		/*SystemEventType.raiseEvent(new SystemEventType(
 				SystemEventType.TYPE_USER_LOGIN, id), System
 				.currentTimeMillis(), true, new LocalizableMessage(
-				"event.login", username));
+				"event.login", username));*/
 	}
 
+	@Deprecated
 	public void valueUnbound(HttpSessionBindingEvent evt) {
 		// User is unbound from a session when logged out or the session
 		// expires.
-		SystemEventType.returnToNormal(new SystemEventType(
+		/*SystemEventType.returnToNormal(new SystemEventType(
 				SystemEventType.TYPE_USER_LOGIN, id), System
 				.currentTimeMillis());
 
 		// Terminate any testing utility
 		if (testingUtility != null)
-			testingUtility.cancel();
+			testingUtility.cancel();*/
 	}
 
 	// Convenience method for JSPs

--- a/src/org/scada_lts/dao/DAO.java
+++ b/src/org/scada_lts/dao/DAO.java
@@ -25,11 +25,9 @@ import javax.sql.DataSource;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.scada_lts.web.beans.ApplicationBeans;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
-
-import com.serotonin.mango.Common;
-
 
 /** 
  * Data Abstract Object
@@ -48,7 +46,7 @@ public class DAO {
 	private DAO() {
 		try {
 			LOG.trace("Create DAO");
-			DataSource ds = Common.ctx.getDatabaseAccess().getDataSource();
+			DataSource ds = ApplicationBeans.getDatabaseSourceBean();
 			namedParamJdbcTemplate = new NamedParameterJdbcTemplate(ds);
 			jdbcTemplate = new JdbcTemplate(ds);
 		} catch (Exception e) {

--- a/src/org/scada_lts/login/AuthenticationUtils.java
+++ b/src/org/scada_lts/login/AuthenticationUtils.java
@@ -1,9 +1,11 @@
 package org.scada_lts.login;
 
 import com.serotonin.mango.Common;
+import com.serotonin.mango.rt.event.type.SystemEventType;
 import com.serotonin.mango.vo.User;
 import com.serotonin.mango.web.integration.CrowdUtils;
 import com.serotonin.mango.web.mvc.controller.ControllerUtils;
+import com.serotonin.web.i18n.LocalizableMessage;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.scada_lts.mango.adapter.MangoUser;
@@ -53,6 +55,10 @@ public final class AuthenticationUtils {
         getUser(authentication, mangoUser).ifPresent(user -> {
             authenticateLocal(request, response, authentication, user);
             mangoUser.recordLogin(user.getId());
+            SystemEventType.raiseEvent(new SystemEventType(
+                    SystemEventType.TYPE_USER_LOGIN, user.getId()), System
+                    .currentTimeMillis(), true, new LocalizableMessage(
+                    "event.login", user.getUsername()));
         });
         User user = Common.getUser(request);
         if(user == null) {

--- a/src/org/scada_lts/login/ScadaHeaderWriterLogoutHandler.java
+++ b/src/org/scada_lts/login/ScadaHeaderWriterLogoutHandler.java
@@ -1,5 +1,10 @@
 package org.scada_lts.login;
 
+import com.serotonin.mango.Common;
+import com.serotonin.mango.rt.event.type.SystemEventType;
+import com.serotonin.mango.vo.User;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.springframework.security.web.header.HeaderWriter;
@@ -12,6 +17,8 @@ import java.io.IOException;
 
 public final class ScadaHeaderWriterLogoutHandler implements LogoutSuccessHandler {
 
+    private static final Log LOG = LogFactory.getLog(ScadaHeaderWriterLogoutHandler.class);
+
     private final HeaderWriter headerWriter;
 
     public ScadaHeaderWriterLogoutHandler(HeaderWriter headerWriter) {
@@ -22,6 +29,19 @@ public final class ScadaHeaderWriterLogoutHandler implements LogoutSuccessHandle
     @Override
     public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         this.headerWriter.writeHeaders(request, response);
+        resetUser(request);
         response.sendRedirect("login.htm");
+    }
+
+    private static void resetUser(HttpServletRequest request) {
+        try {
+            User user = Common.getUser(request);
+            SystemEventType.returnToNormal(new SystemEventType(
+                    SystemEventType.TYPE_USER_LOGIN, user.getId()), System
+                    .currentTimeMillis());
+            user.cancelTestingUtility();
+        } catch (Exception ex) {
+            LOG.warn(ex.getMessage(), ex);
+        }
     }
 }

--- a/src/org/scada_lts/service/HighestAlarmLevelServiceWithCache.java
+++ b/src/org/scada_lts/service/HighestAlarmLevelServiceWithCache.java
@@ -15,7 +15,6 @@ import org.scada_lts.quartz.CronTriggerScheduler;
 import org.scada_lts.web.ws.model.AlarmLevelMessage;
 import org.springframework.stereotype.Service;
 
-import javax.annotation.PostConstruct;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
@@ -44,8 +43,7 @@ public class HighestAlarmLevelServiceWithCache implements IHighestAlarmLevelServ
         this.userService = new UserService();
     }
 
-    @PostConstruct
-    private void init() {
+    public void init() {
         try {
             boolean resetEnabled = ScadaConfig.getInstance().getBoolean(RESET_ENABLED_KEY, false);
             if(resetEnabled) {

--- a/src/org/scada_lts/web/beans/ApplicationBeans.java
+++ b/src/org/scada_lts/web/beans/ApplicationBeans.java
@@ -30,6 +30,7 @@ import org.scada_lts.web.ws.services.UserEventServiceWebSocket;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
 
+import javax.sql.DataSource;
 import java.util.Optional;
 
 public class ApplicationBeans {
@@ -131,6 +132,23 @@ public class ApplicationBeans {
 
     }
 
+    public static DataSource getDatabaseSourceBean() {
+        return getBeanFromContext("databaseSource", DataSource.class);
+    }
+
+    public static UserEventServiceWebSocket getUserEventServiceWebsocketBean() {
+        return getBeanFromContext("userEventServiceWebSocket", UserEventServiceWebSocket.class);
+    }
+
+    public static DataPointServiceWebSocket getDataPointServiceWebSocketBean() {
+        return getBeanFromContext("dataPointServiceWebSocket", DataPointServiceWebSocket.class);
+    }
+
+    public static EventsServiceWebSocket getEventsServiceWebSocketBean() {
+        return getBeanFromContext("eventsServiceWebSocket", EventsServiceWebSocket.class);
+    }
+
+    @Deprecated
     public static class Lazy {
 
         private Lazy() {}
@@ -151,7 +169,7 @@ public class ApplicationBeans {
             try {
                 return Optional.ofNullable(get(beanName, clazz));
             } catch (NoSuchBeanDefinitionException ex) {
-                LOG.debug(ex);
+                LOG.error(ex);
                 return Optional.empty();
             } catch (Exception ex) {
                 LOG.error(ex.getMessage(), ex);

--- a/src/org/scada_lts/web/beans/GetSecurityBeans.java
+++ b/src/org/scada_lts/web/beans/GetSecurityBeans.java
@@ -1,0 +1,19 @@
+package org.scada_lts.web.beans;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+class GetSecurityBeans implements ApplicationContextAware {
+
+    private static ApplicationContext servletContext;
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        GetSecurityBeans.servletContext = applicationContext;
+    }
+
+    static ApplicationContext context() {
+        return servletContext;
+    }
+}

--- a/src/org/scada_lts/web/beans/ScadaContextClosedEvent.java
+++ b/src/org/scada_lts/web/beans/ScadaContextClosedEvent.java
@@ -1,0 +1,26 @@
+package org.scada_lts.web.beans;
+
+import com.serotonin.mango.MangoContextListener;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.ServletContextEvent;
+
+@Component
+public class ScadaContextClosedEvent implements ApplicationListener<ContextClosedEvent> {
+
+    private final MangoContextListener mangoContextListener;
+
+    public ScadaContextClosedEvent(MangoContextListener mangoContextListener) {
+        this.mangoContextListener = mangoContextListener;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent contextRefreshedEvent) {
+        WebApplicationContext webApplicationContext = (WebApplicationContext)contextRefreshedEvent.getSource();
+        ServletContextEvent servletContextEvent = new ServletContextEvent(webApplicationContext.getServletContext());
+        mangoContextListener.contextDestroyed(servletContextEvent);
+    }
+}

--- a/src/org/scada_lts/web/beans/ScadaContextRefreshedEvent.java
+++ b/src/org/scada_lts/web/beans/ScadaContextRefreshedEvent.java
@@ -1,0 +1,26 @@
+package org.scada_lts.web.beans;
+
+import com.serotonin.mango.MangoContextListener;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+import javax.servlet.ServletContextEvent;
+
+@Component
+public class ScadaContextRefreshedEvent implements ApplicationListener<ContextRefreshedEvent> {
+
+    private final MangoContextListener mangoContextListener;
+
+    public ScadaContextRefreshedEvent(MangoContextListener mangoContextListener) {
+        this.mangoContextListener = mangoContextListener;
+    }
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
+        WebApplicationContext webApplicationContext = (WebApplicationContext)contextRefreshedEvent.getSource();
+        ServletContextEvent servletContextEvent = new ServletContextEvent(webApplicationContext.getServletContext());
+        mangoContextListener.contextInitialized(servletContextEvent);
+    }
+}

--- a/test/com/serotonin/mango/rt/RuntimeManagerCreateDataPointRtTest.java
+++ b/test/com/serotonin/mango/rt/RuntimeManagerCreateDataPointRtTest.java
@@ -42,7 +42,7 @@ public class RuntimeManagerCreateDataPointRtTest {
         JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
         when(dao.getJdbcTemp()).thenReturn(jdbcTemplate);
         whenNew(DAO.class)
-                .withNoArguments()
+                .withAnyArguments()
                 .thenReturn(dao);
 
         DataSourceVO dataSourceVO = new VirtualDataSourceVO();

--- a/test/com/serotonin/mango/rt/dataImage/datapointrt/config/ConfigDataPointRtTest.java
+++ b/test/com/serotonin/mango/rt/dataImage/datapointrt/config/ConfigDataPointRtTest.java
@@ -7,10 +7,7 @@ import com.serotonin.mango.db.dao.DataPointDao;
 import com.serotonin.mango.db.dao.DataSourceDao;
 import com.serotonin.mango.rt.EventManager;
 import com.serotonin.mango.rt.RuntimeManager;
-import com.serotonin.mango.rt.dataImage.AnnotatedPointValueTime;
-import com.serotonin.mango.rt.dataImage.DataPointRT;
-import com.serotonin.mango.rt.dataImage.DataPointSyncMode;
-import com.serotonin.mango.rt.dataImage.PointValueTime;
+import com.serotonin.mango.rt.dataImage.*;
 import com.serotonin.mango.rt.dataImage.types.MangoValue;
 import com.serotonin.mango.rt.dataSource.virtual.VirtualDataSourceRT;
 import com.serotonin.mango.rt.maint.BackgroundProcessing;
@@ -38,6 +35,8 @@ import org.scada_lts.mango.service.DataPointService;
 import org.scada_lts.mango.service.DataSourceService;
 import org.scada_lts.mango.service.PointValueService;
 import org.scada_lts.mango.service.SystemSettingsService;
+import org.scada_lts.web.beans.ApplicationBeans;
+import org.scada_lts.web.ws.services.DataPointServiceWebSocket;
 import org.springframework.jdbc.core.JdbcTemplate;
 import utils.PointValueDAOMemory;
 
@@ -47,14 +46,13 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.clearInvocations;
 import static org.powermock.api.mockito.PowerMockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({DAO.class, Common.class, PointValueDAO.class, PointValueAdnnotationsDAO.class,
         DataPointDao.class, DataSourceDao.class, VirtualDataSourceRT.class, RuntimeManager.class,
-        PointValueService.class, PointValueDAO.class})
+        PointValueService.class, PointValueDAO.class, ApplicationBeans.class})
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})
 public class ConfigDataPointRtTest {
@@ -164,7 +162,7 @@ public class ConfigDataPointRtTest {
         JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
         when(dao.getJdbcTemp()).thenReturn(jdbcTemplate);
         whenNew(DAO.class)
-                .withNoArguments()
+                .withAnyArguments()
                 .thenReturn(dao);
 
         dataSourceVO = new VirtualDataSourceVO();
@@ -263,6 +261,10 @@ public class ConfigDataPointRtTest {
         whenNew(SystemSettingsService.class)
                 .withNoArguments()
                 .thenReturn(systemSettingsServiceMock);
+
+        mockStatic(ApplicationBeans.class);
+        DataPointServiceWebSocket dataPointServiceWebSocket = mock(DataPointServiceWebSocket.class);
+        when(ApplicationBeans.getDataPointServiceWebSocketBean()).thenReturn(dataPointServiceWebSocket);
     }
 
     public void clear() {

--- a/test/com/serotonin/mango/rt/dataSource/meta/ScriptExecutorTest.java
+++ b/test/com/serotonin/mango/rt/dataSource/meta/ScriptExecutorTest.java
@@ -6,6 +6,7 @@ import br.org.scadabr.rt.scripting.context.ScriptContextObject;
 import com.serotonin.mango.Common;
 import com.serotonin.mango.rt.RuntimeManager;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.ScriptTestUtils;
 import com.serotonin.mango.rt.dataImage.DataPointRT;
 import com.serotonin.mango.rt.dataImage.IDataPoint;
@@ -34,7 +35,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        ScriptExecutor.class, Common.class})
+        ScriptExecutor.class, Common.class, ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/com/serotonin/mango/rt/scripting/ScriptTest.java
+++ b/test/com/serotonin/mango/rt/scripting/ScriptTest.java
@@ -20,6 +20,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import org.scada_lts.dao.DAO;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.IntValuePairPrinted;
 import utils.ScriptTestUtils;
 
@@ -39,7 +40,7 @@ import static utils.Scripts.createScriptWithJavaViewDwr;
 @PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        Common.class})
+        Common.class, ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/com/serotonin/mango/rt/scripting/ScriptWithObjectContextEnableDisableDataPointTest.java
+++ b/test/com/serotonin/mango/rt/scripting/ScriptWithObjectContextEnableDisableDataPointTest.java
@@ -8,6 +8,7 @@ import com.serotonin.db.IntValuePair;
 import com.serotonin.mango.Common;
 import com.serotonin.mango.rt.RuntimeManager;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.ScriptTestUtils;
 import com.serotonin.mango.rt.dataImage.PointValueCache;
 import com.serotonin.mango.vo.permission.Permissions;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        Common.class})
+        Common.class, ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/com/serotonin/mango/rt/scripting/ScriptWithObjectContextEnableDisableDataSourceTest.java
+++ b/test/com/serotonin/mango/rt/scripting/ScriptWithObjectContextEnableDisableDataSourceTest.java
@@ -8,6 +8,7 @@ import com.serotonin.db.IntValuePair;
 import com.serotonin.mango.Common;
 import com.serotonin.mango.rt.RuntimeManager;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.ScriptTestUtils;
 import com.serotonin.mango.rt.dataImage.PointValueCache;
 import com.serotonin.mango.vo.permission.Permissions;
@@ -32,7 +33,7 @@ import static utils.Scripts.createScriptWithObjectContextEnableDataSource;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        Common.class})
+        Common.class, ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/com/serotonin/mango/rt/scripting/ScriptWithObjectContextWriteDataPointTest.java
+++ b/test/com/serotonin/mango/rt/scripting/ScriptWithObjectContextWriteDataPointTest.java
@@ -8,6 +8,7 @@ import com.serotonin.db.IntValuePair;
 import com.serotonin.mango.Common;
 import com.serotonin.mango.rt.RuntimeManager;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.IntValuePairPrinted;
 import utils.ScriptTestUtils;
 import com.serotonin.mango.rt.dataImage.DataPointRT;
@@ -36,7 +37,7 @@ import static utils.Scripts.createScriptWithObjectContextWriteDataPoint;
 @PowerMockRunnerDelegate(Parameterized.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        Common.class})
+        Common.class, ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/com/serotonin/mango/view/component/ButtonComponentTest.java
+++ b/test/com/serotonin/mango/view/component/ButtonComponentTest.java
@@ -24,6 +24,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.scada_lts.dao.DAO;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.ScriptTestUtils;
 
 import java.util.HashMap;
@@ -35,7 +36,7 @@ import static org.mockito.Mockito.mock;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        ScriptExecutor.class, Common.class})
+        ScriptExecutor.class, Common.class, ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/com/serotonin/mango/view/component/ScriptComponentTest.java
+++ b/test/com/serotonin/mango/view/component/ScriptComponentTest.java
@@ -24,6 +24,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.scada_lts.dao.DAO;
+import org.scada_lts.web.beans.ApplicationBeans;
 import utils.ScriptTestUtils;
 
 import java.util.*;
@@ -36,7 +37,8 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({DAO.class, PointValueCache.class, Permissions.class,
         ContextualizedScriptRT.class, ScriptContextObject.class,
-        ScriptExecutor.class, Common.class, ScriptComponent.class})
+        ScriptExecutor.class, Common.class, ScriptComponent.class,
+        ApplicationBeans.class})
 // resources/org/powermock/extensions/configuration.properties is not working
 @PowerMockIgnore({"com.sun.org.apache.xerces.*", "javax.xml.*", "org.xml.*", "org.w3c.*", "com.sun.org.apache.xalan.*",
         "javax.activation.*", "javax.management.*"})

--- a/test/utils/ScriptTestUtils.java
+++ b/test/utils/ScriptTestUtils.java
@@ -13,16 +13,16 @@ import com.serotonin.mango.vo.User;
 import com.serotonin.mango.vo.dataSource.PointLocatorVO;
 import com.serotonin.mango.vo.dataSource.virtual.VirtualPointLocatorVO;
 import com.serotonin.mango.vo.permission.Permissions;
+import org.scada_lts.web.beans.ApplicationBeans;
+import org.scada_lts.web.ws.services.DataPointServiceWebSocket;
 import utils.mock.MockUtils;
 
 import java.util.*;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 public class ScriptTestUtils {
 
@@ -66,6 +66,10 @@ public class ScriptTestUtils {
         when(ScriptContextObject.Type.valueOf(anyInt()))
                 .thenReturn(type);
         when(type.createScriptContextObject()).thenReturn(scriptContextObject);
+
+        mockStatic(ApplicationBeans.class);
+        DataPointServiceWebSocket dataPointServiceWebSocket = mock(DataPointServiceWebSocket.class);
+        when(ApplicationBeans.getDataPointServiceWebSocketBean()).thenReturn(dataPointServiceWebSocket);
     }
 
 }

--- a/test/utils/mock/MockUtils.java
+++ b/test/utils/mock/MockUtils.java
@@ -1,12 +1,10 @@
 package utils.mock;
 
-import br.org.scadabr.rt.scripting.context.ScriptContextObject;
 import com.serotonin.mango.Common;
 import com.serotonin.mango.db.dao.PointValueDao;
 import com.serotonin.mango.db.dao.UserDao;
 import com.serotonin.mango.rt.RuntimeManager;
 import com.serotonin.mango.vo.User;
-import com.serotonin.mango.vo.permission.Permissions;
 import com.serotonin.mango.web.ContextWrapper;
 import com.serotonin.util.PropertiesUtils;
 import org.scada_lts.dao.DAO;
@@ -42,7 +40,7 @@ public class MockUtils {
         JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
         when(dao.getJdbcTemp()).thenReturn(jdbcTemplate);
         whenNew(DAO.class)
-                .withNoArguments()
+                .withAnyArguments()
                 .thenReturn(dao);
 
         UserDao userDao = mock(UserDao.class);


### PR DESCRIPTION
…ext MangoContextListener moved to ScadaContextRefreshedEvent, after initialized spring dispatcher servlet, destroy context moved to ScadaContextClosedEvent, removed MangoContextListener in web.xml; Created GetSecurityBeans; def databaseSource moved to applicationContext.xml from spring-security.xml; highestAlarmLevelServiceWithCache disabled lazy-init; BasePooledAccess.initializeImpl(String propertyPrefix, String dataSourceName) databaseSource using from Spring container; DataPointRT - created fields dataPointServiceWebSocket, pointValueService; EventManager - created fields userEventServiceWebsocket, eventsServiceWebSocket; deprecated: User.valueBound moved to AuthenticationUtils, User.valueUnbound moved to ScadaHeaderWriterLogoutHandler, ApplicationBeans.Lazy; HighestAlarmLevelServiceWithCache - changed init method, removed @PostConstruct on init(), initialized in MangoContextListener; corrected tests: ConfigDataPointRtTest, ScriptExecutorTest, ScriptTest, ScriptWithObjectContextEnableDisableDataPointTest, ScriptWithObjectContextEnableDisableDataSourceTest, ScriptWithObjectContextWriteDataPointTest, RuntimeManagerCreateDataPointRtTest, ButtonComponentTest, ScriptComponentTest and MockUtils, ScriptTestUtils;