### PR TITLE
Fix issue 2456

### DIFF
--- a/WebContent/WEB-INF/jsp/watchList.jsp
+++ b/WebContent/WEB-INF/jsp/watchList.jsp
@@ -461,6 +461,8 @@
     	  jQuery("#imageChartLiveImg").attr('src', 'images/control_play_blue.png');
           var width = dojo.html.getContentBox($("imageChartDiv")).width - 20;
           var height = dojo.html.getContentBox($("chartContainer")).height - 80;
+	  width = Math.trunc(width);
+	  height = Math.trunc(height);
     	  height = height < 100 ? 100 : height;
           startImageFader($("imageChartImg"));
           WatchListDwr.getImageChartData(getChartPointList(), $get("fromYear"), $get("fromMonth"), $get("fromDay"),


### PR DESCRIPTION
When browser zoom differs from 100%, the height var receives a float number, but the parameter of WatchListDwr.getImageChartData is integer