### PR TITLE
#2533 Basic auth by HTTPS for API httpds - update spring-security.xml…

### DIFF
--- a/WebContent/WEB-INF/spring-security.xml
+++ b/WebContent/WEB-INF/spring-security.xml
@@ -23,6 +23,23 @@
         <session-management session-fixation-protection="newSession" />
     </http>
 
+    <http use-expressions="true" disable-url-rewriting="true" pattern="/httpds/**"
+          authentication-manager-ref="authenticationManager" entry-point-ref="basicAuthenticationEntryPoint">
+        <headers>
+            <cache-control disabled="true"/>
+            <content-type-options disabled="true"/>
+            <hsts/>
+            <frame-options policy="SAMEORIGIN"/>
+            <xss-protection/>
+            <header ref="headersFromSystemSettingsWriter"/>
+        </headers>
+        <csrf disabled="true"/>
+        <intercept-url pattern="/**" access="hasAnyRole('ROLE_ADMIN', 'ROLE_USER')" requires-channel="https"/>
+
+        <custom-filter position="BASIC_AUTH_FILTER" ref="basicAuthFilter"/>
+        <session-management session-fixation-protection="newSession" />
+    </http>
+
     <http use-expressions="true" disable-url-rewriting="true"
           authentication-manager-ref="authenticationManager">
         <headers>

--- a/src/com/serotonin/mango/web/dwr/PublisherEditDwr.java
+++ b/src/com/serotonin/mango/web/dwr/PublisherEditDwr.java
@@ -18,7 +18,6 @@
  */
 package com.serotonin.mango.web.dwr;
 
-import java.net.*;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Iterator;
@@ -212,11 +211,6 @@ public class PublisherEditDwr extends BaseDwr {
         HttpSenderVO p = (HttpSenderVO) Common.getUser().getEditPublisher();
 
         return p.isUseJSON();
-    }
-
-    public void httpSenderTest(String url, boolean usePost, List<KeyValuePair> staticHeaders,
-            List<KeyValuePair> staticParameters) {
-        Common.getUser().setTestingUtility(new HttpSenderTester(url, usePost, staticHeaders, staticParameters));
     }
 
     public String httpSenderTestUpdate() {

--- a/src/org/scada_lts/login/LocalBasicAuthFilter.java
+++ b/src/org/scada_lts/login/LocalBasicAuthFilter.java
@@ -1,5 +1,6 @@
 package org.scada_lts.login;
 
+import com.serotonin.mango.vo.User;
 import org.scada_lts.mango.service.UserService;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.core.Authentication;
@@ -19,6 +20,7 @@ public class LocalBasicAuthFilter extends BasicAuthenticationFilter {
     @Override
     protected void onSuccessfulAuthentication(HttpServletRequest request,
                                               HttpServletResponse response, Authentication authentication) {
-        authenticateLocal(request, response, authentication, new UserService());
+        User user = new UserService().getUser(authentication.getName());
+        authenticateLocal(request, response, authentication, user);
     }
 }


### PR DESCRIPTION
… configuration - added auth basic for /httpds by https; removed not use PublisherEditDwr.httpSenderTest(); basic auth without generate login event;