### PR TITLE
#2521 Text "double click to close" inside datapoint details without need

### DIFF
--- a/WebContent/WEB-INF/snippet/changeContentText.jsp
+++ b/WebContent/WEB-INF/snippet/changeContentText.jsp
@@ -22,5 +22,7 @@
         onkeypress="if (event.keyCode==13) $('txtSet${componentId}').onclick();"/>
 <a id="txtSet${componentId}" class="ptr"
         onclick="mango.view.setPoint(${point.id}, '${componentId}', $('txtChange${componentId}').value);"><fmt:message key="common.set"/></a>
-        </br>Double click to close
+<c:if test="${!hideClosingHint}" >
+    </br>Double click to close
+</c:if>
 <tag:relinquish/>

--- a/scadalts-ui/src/locales/en.json
+++ b/scadalts-ui/src/locales/en.json
@@ -199,7 +199,7 @@
 	"datapointDetails.valueHistory.stats.max": "Maximum Value:",
 	"datapointDetails.valueHistory.stats.min": "Minimum Value:",
 	"datapointDetails.valueHistory.stats.sum": "Summary Value:",
-	"datapointDetails.valueHistory.stats.timeperiod": "Show history form",
+	"datapointDetails.valueHistory.stats.timeperiod": "Show history from",
 	"datapointDetails.valueHistory.subtitle": "History",
 	"datapointDetails.valueHistory.table.count": "Count",
 	"datapointDetails.valueHistory.table.date": "Date",

--- a/src/com/serotonin/mango/web/dwr/DataPointDetailsDwr.java
+++ b/src/com/serotonin/mango/web/dwr/DataPointDetailsDwr.java
@@ -71,9 +71,9 @@ public class DataPointDetailsDwr extends BaseDwr {
 		PointValueTime pointValue = prepareBasePointState(Integer.toString(pointVO.getId()), state, pointVO, pointRT,
 				model);
 		setPrettyTextWithoutEqual(state, pointVO, model, pointValue);
+		model.put("hideClosingHint", true);
 		if (state.getValue() != null)
 			setChange(pointVO, state, pointRT, request, model, user);
-
 		setEvents(pointVO, user, model);
 		setMessages(state, request, "watchListMessages", model);
 

--- a/src/com/serotonin/mango/web/dwr/DataPointDetailsDwr.java
+++ b/src/com/serotonin/mango/web/dwr/DataPointDetailsDwr.java
@@ -71,9 +71,10 @@ public class DataPointDetailsDwr extends BaseDwr {
 		PointValueTime pointValue = prepareBasePointState(Integer.toString(pointVO.getId()), state, pointVO, pointRT,
 				model);
 		setPrettyTextWithoutEqual(state, pointVO, model, pointValue);
-		model.put("hideClosingHint", true);
-		if (state.getValue() != null)
+		if (state.getValue() != null) {
+			model.put("hideClosingHint", true);
 			setChange(pointVO, state, pointRT, request, model, user);
+		}
 		setEvents(pointVO, user, model);
 		setMessages(state, request, "watchListMessages", model);
 


### PR DESCRIPTION
- Added if condition in changeContentText.jsp which checks if point that is being edited is in Point Detail Menu.
- Added hideClosingHint flag for model to use it in if condition
- Small fix with translation