### PR TITLE
#2623 Fixed Gradle task 'deployTomcat' doesn't return error when build/libs folder is empty/deleted

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,13 +96,13 @@ task clearTomcat(type: Delete) {
     delete file(System.getenv("CATALINA_HOME") + "/webapps/ScadaBR.war")
 }
 
-task doesScadaLTSWarFileExists {
+task existsScadaLTSWarFile {
     doLast {
         assert file("build/libs/Scada-LTS.war").exists()
     }
 }
 
-task deployTomcat(type: Copy, dependsOn: fileExistScadaLTS) {
+task deployTomcat(type: Copy, dependsOn: existsScadaLTSWarFile) {
     from "build/libs/"
     into System.getenv("CATALINA_HOME")+ "/webapps"
     include('Scada-LTS.war')

--- a/build.gradle
+++ b/build.gradle
@@ -96,7 +96,13 @@ task clearTomcat(type: Delete) {
     delete file(System.getenv("CATALINA_HOME") + "/webapps/ScadaBR.war")
 }
 
-task deployTomcat(type: Copy) {
+task doesScadaLTSWarFileExists {
+    doLast {
+        assert file("build/libs/Scada-LTS.war").exists()
+    }
+}
+
+task deployTomcat(type: Copy, dependsOn: fileExistScadaLTS) {
     from "build/libs/"
     into System.getenv("CATALINA_HOME")+ "/webapps"
     include('Scada-LTS.war')


### PR DESCRIPTION

- Added task in build.gradle that checks for .war file in build/libs every time 'deployTeomcat' task is used