### PR TITLE
#2694 Work-items API extension -

### DIFF
--- a/doc/ThreadInfoAPI.yaml
+++ b/doc/ThreadInfoAPI.yaml
@@ -41,7 +41,16 @@ paths:
         '200':
           description: 'Get successful'
           headers: { }
-  /threads/group-by/count/:
+  /threads/classes/:
+    get:
+      tags:
+        - ThreadInfoAPI
+      description: 'Get all thread classes'
+      responses:
+        '200':
+          description: 'Get successful'
+          headers: { }
+  /threads/group-by/classes/count/:
     get:
       tags:
         - ThreadInfoAPI
@@ -50,34 +59,7 @@ paths:
         '200':
           description: 'Get successful'
           headers: { }
-  /threads/group-by/thread-stack/:
-    get:
-      tags:
-        - ThreadInfoAPI
-      description: 'Group stacks by thread'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-  /threads/group-by/thread-stack/classes/:
-    get:
-      tags:
-        - ThreadInfoAPI
-      description: 'Group stack classes by thread'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-  /threads/group-by/thread-stack/count/:
-    get:
-      tags:
-        - ThreadInfoAPI
-      description: 'Group stacks count by thread'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-  /threads/group-by/stack-thread/:
+  /threads/group-by/stack/:
     get:
       tags:
         - ThreadInfoAPI
@@ -86,7 +68,7 @@ paths:
         '200':
           description: 'Get successful'
           headers: { }
-  /threads/group-by/stack-thread/classes/:
+  /threads/group-by/stack/classes/:
     get:
       tags:
         - ThreadInfoAPI
@@ -95,7 +77,7 @@ paths:
         '200':
           description: 'Get successful'
           headers: { }
-  /threads/group-by/stack-thread/count/:
+  /threads/group-by/stack/count/:
     get:
       tags:
         - ThreadInfoAPI
@@ -104,11 +86,47 @@ paths:
         '200':
           description: 'Get successful'
           headers: { }
-  /threads/group-by/stack-thread/names/:
+  /threads/group-by/stack/names/:
     get:
       tags:
         - ThreadInfoAPI
       description: 'Group threads by stack then names'
+      responses:
+        '200':
+          description: 'Get successful'
+          headers: { }
+  /threads/group-by/states/:
+    get:
+      tags:
+        - StateThreadInfoAPI
+      description: 'Group threads by state'
+      responses:
+        '200':
+          description: 'Get successful'
+          headers: { }
+  /threads/group-by/states/classes/:
+    get:
+      tags:
+        - StateThreadInfoAPI
+      description: 'Group thread classes by state'
+      responses:
+        '200':
+          description: 'Get successful'
+          headers: { }
+  /threads/group-by/states/count/:
+    get:
+      tags:
+        - StateThreadInfoAPI
+      description: 'Group threads count by state'
+      responses:
+        '200':
+          description: 'Get successful'
+          headers: { }
+  /threads/group-by/states/names/:
+    get:
+      tags:
+        - StateThreadInfoAPI
+      description: 'Group thread namew by state'
       responses:
         '200':
           description: 'Get successful'
@@ -122,7 +140,7 @@ paths:
         '200':
           description: 'Get successful'
           headers: { }
-  /threads/states/state/{state}/:
+  /threads/states/{state}/:
     get:
       tags:
         - StateThreadInfoAPI
@@ -138,23 +156,7 @@ paths:
           schema:
             type: 'string'
             enum: [NEW, RUNNABLE, BLOCKED, WAITING, TIMED_WAITING, TERMINATED]
-  /threads/states/state/{state}/count/:
-    get:
-      tags:
-        - StateThreadInfoAPI
-      description: 'Get threads count for state'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-      parameters:
-        - name: 'state'
-          in: 'path'
-          required: true
-          schema:
-            type: 'string'
-            enum: [NEW, RUNNABLE, BLOCKED, WAITING, TIMED_WAITING, TERMINATED]
-  /threads/states/state/{state}/classes/:
+  /threads/states/{state}/classes/:
     get:
       tags:
         - StateThreadInfoAPI
@@ -170,7 +172,7 @@ paths:
           schema:
             type: 'string'
             enum: [NEW, RUNNABLE, BLOCKED, WAITING, TIMED_WAITING, TERMINATED]
-  /threads/states/state/{state}/names/:
+  /threads/states/{state}/names/:
     get:
       tags:
         - StateThreadInfoAPI
@@ -186,39 +188,3 @@ paths:
           schema:
             type: 'string'
             enum: [NEW, RUNNABLE, BLOCKED, WAITING, TIMED_WAITING, TERMINATED]
-  /threads/states/group-by/:
-    get:
-      tags:
-        - StateThreadInfoAPI
-      description: 'Group threads by state'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-  /threads/states/group-by/count/:
-    get:
-      tags:
-        - StateThreadInfoAPI
-      description: 'Group threads count by state'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-  /threads/states/group-by/classes/:
-    get:
-      tags:
-        - StateThreadInfoAPI
-      description: 'Group thread classes by state'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }
-  /threads/states/group-by/names/:
-    get:
-      tags:
-        - StateThreadInfoAPI
-      description: 'Group thread namew by state'
-      responses:
-        '200':
-          description: 'Get successful'
-          headers: { }

--- a/doc/WorkItemInfoAPI.yaml
+++ b/doc/WorkItemInfoAPI.yaml
@@ -23,7 +23,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/group-by/:
+  /work-items/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -32,7 +32,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/group-by/count/:
+  /work-items/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -50,7 +50,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/executed/group-by/:
+  /work-items/executed/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -59,7 +59,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/executed/group-by/count/:
+  /work-items/executed/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -77,7 +77,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/failed/group-by/:
+  /work-items/failed/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -86,7 +86,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/failed/group-by/count/:
+  /work-items/failed/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -104,7 +104,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/running/group-by/:
+  /work-items/running/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -113,7 +113,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/running/group-by/count/:
+  /work-items/running/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -131,7 +131,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/success/group-by/:
+  /work-items/success/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -140,7 +140,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/success/group-by/count/:
+  /work-items/success/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -158,7 +158,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/all/group-by/:
+  /work-items/all/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -167,7 +167,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/all/group-by/count/:
+  /work-items/all/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -191,7 +191,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/longer/{executedMs}/group-by/:
+  /work-items/longer/{executedMs}/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -206,7 +206,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/longer/{executedMs}/group-by/count/:
+  /work-items/longer/{executedMs}/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -221,7 +221,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/longer/{executedMs}/history/:
+  /work-items/history/longer/{executedMs}/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -236,7 +236,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/longer/{executedMs}/history/group-by/:
+  /work-items/history/longer/{executedMs}/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -251,7 +251,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/longer/{executedMs}/history/group-by/count/:
+  /work-items/history/longer/{executedMs}/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -281,7 +281,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/less/{executedMs}/group-by/:
+  /work-items/less/{executedMs}/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -296,7 +296,7 @@ paths:
           required: true
           schema:
             type: 'integer'
-  /work-items/less/{executedMs}/group-by/count/:
+  /work-items/less/{executedMs}/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -327,7 +327,7 @@ paths:
           schema:
             type: 'string'
             enum: [ HIGH, MEDIUM, LOW ]
-  /work-items/priority/{priority}/group-by/:
+  /work-items/priority/{priority}/group-by-classes/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -343,7 +343,7 @@ paths:
           schema:
             type: 'string'
             enum: [ HIGH, MEDIUM, LOW ]
-  /work-items/priority/{priority}/group-by/count/:
+  /work-items/priority/{priority}/group-by-classes/count/:
     get:
       tags:
         - WorkItemInfoAPI
@@ -368,7 +368,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/scheduled/group-by/:
+  /work-items/scheduled/group-by-classes/:
     get:
       tags:
         - ScheduledWorkItemInfoAPI
@@ -377,7 +377,7 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/scheduled/group-by/count/:
+  /work-items/scheduled/group-by-classes/count/:
     get:
       tags:
         - ScheduledWorkItemInfoAPI
@@ -386,7 +386,16 @@ paths:
         '200':
           description: "Get successful"
           headers: { }
-  /work-items/scheduled/state/{state}/:
+  /work-items/scheduled/states/:
+    get:
+      tags:
+        - ScheduledWorkItemInfoAPI
+      description: 'Get active scheduled work items'
+      responses:
+        '200':
+          description: "Get successful"
+          headers: { }
+  /work-items/scheduled/states/{state}/:
     get:
       tags:
         - ScheduledWorkItemInfoAPI
@@ -402,7 +411,7 @@ paths:
           schema:
             type: 'string'
             enum: [ VIRGIN, CANCELLED, EXECUTED, SCHEDULED ]
-  /work-items/scheduled/state/{state}/group-by/:
+  /work-items/scheduled/states/{state}/group-by-classes/:
     get:
       tags:
         - ScheduledWorkItemInfoAPI
@@ -418,7 +427,7 @@ paths:
           schema:
             type: 'string'
             enum: [ VIRGIN, CANCELLED, EXECUTED, SCHEDULED ]
-  /work-items/scheduled/state/{state}/group-by/count/:
+  /work-items/scheduled/states/{state}/group-by-classes/count/:
     get:
       tags:
         - ScheduledWorkItemInfoAPI

--- a/src/com/serotonin/mango/rt/maint/work/WorkItemMetrics.java
+++ b/src/com/serotonin/mango/rt/maint/work/WorkItemMetrics.java
@@ -6,5 +6,7 @@ public interface WorkItemMetrics {
     boolean isWorkFailed();
     boolean isRunning();
     int getExecutedMs();
-    String getErrorMessage();
+    String getFailedMessage();
+    String getWorkFailedMessage();
+    String getThreadName();
 }

--- a/src/com/serotonin/mango/rt/publish/persistent/PersistentSendThread.java
+++ b/src/com/serotonin/mango/rt/publish/persistent/PersistentSendThread.java
@@ -8,6 +8,7 @@ import java.text.ParseException;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import com.serotonin.mango.rt.maint.work.WorkItemPriority;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -395,7 +396,7 @@ class PersistentSendThread extends SendThread {
         }
 
         syncHandler = new SyncHandler(this);
-        Common.timer.execute(syncHandler);
+        Common.timer.execute(syncHandler, WorkItemPriority.HIGH + " - name: " + this.getName() + ", id: " + this.getId() + " - " + this.getClass().getName() + ".startSync");
 
         return true;
     }
@@ -418,7 +419,7 @@ class PersistentSendThread extends SendThread {
             public void run() {
                 writePointHierarchy(new DataPointDao().getPointHierarchy());
             }
-        });
+        }, WorkItemPriority.HIGH + " - name: " + this.getName() + ", id: " + this.getId() + " - " + this.getClass().getName() + ".writePointHierarchy");
     }
 
     synchronized void writePointHierarchy(PointHierarchy hierarchy) {

--- a/src/com/serotonin/mango/web/dwr/beans/ImportTask.java
+++ b/src/com/serotonin/mango/web/dwr/beans/ImportTask.java
@@ -50,6 +50,7 @@ import com.serotonin.mango.db.dao.WatchListDao;
 import com.serotonin.mango.rt.dataImage.PointValueTime;
 import com.serotonin.mango.rt.dataImage.types.MangoValue;
 import com.serotonin.mango.rt.event.type.EventType;
+import com.serotonin.mango.rt.maint.work.WorkItemPriority;
 import com.serotonin.mango.util.BackgroundContext;
 import com.serotonin.mango.util.LocalizableJsonException;
 import com.serotonin.mango.view.View;
@@ -173,7 +174,7 @@ public class ImportTask extends ProgressiveTask {
 		usersProfiles = nonNullList(root, EmportDwr.USERS_PROFILES);
 		reports = nonNullList(root, EmportDwr.REPORTS);
 
-		Common.timer.execute(this);
+		Common.timer.execute(this, WorkItemPriority.HIGH + " - " + this.getClass().getName());
 
 	}
 

--- a/src/com/serotonin/timer/AbstractTimer.java
+++ b/src/com/serotonin/timer/AbstractTimer.java
@@ -1,6 +1,7 @@
 package com.serotonin.timer;
 
 import org.apache.commons.lang3.StringUtils;
+import org.scada_lts.utils.ThreadUtils;
 
 import java.util.List;
 
@@ -15,7 +16,7 @@ abstract public class AbstractTimer {
         if (StringUtils.isBlank(name))
             execute(command);
         else
-            execute(new NamedRunnable(command, name));
+            execute(new NamedRunnable(command, ThreadUtils.reduceName(name)));
     }
 
     abstract public void execute(ScheduledRunnable command, long fireTime);
@@ -24,7 +25,7 @@ abstract public class AbstractTimer {
         if (StringUtils.isBlank(name))
             execute(command, fireTime);
         else
-            execute(new ScheduledNamedRunnable(command, name), fireTime);
+            execute(new ScheduledNamedRunnable(command, ThreadUtils.reduceName(name)), fireTime);
     }
 
     final public TimerTask schedule(TimerTask task) {

--- a/src/com/serotonin/timer/sync/SingleExecutorSingleWaiter.java
+++ b/src/com/serotonin/timer/sync/SingleExecutorSingleWaiter.java
@@ -4,6 +4,7 @@
  */
 package com.serotonin.timer.sync;
 
+import com.serotonin.mango.rt.maint.work.WorkItemPriority;
 import com.serotonin.timer.AbstractTimer;
 
 /**
@@ -39,7 +40,7 @@ public class SingleExecutorSingleWaiter {
     }
 
     void executeImpl() {
-        timer.execute(new TaskWrapper(executing));
+        timer.execute(new TaskWrapper(executing), WorkItemPriority.HIGH + " - " + this.getClass().getName());
     }
 
     class TaskWrapper implements Runnable {

--- a/src/com/serotonin/timer/sync/Synchronizer.java
+++ b/src/com/serotonin/timer/sync/Synchronizer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import com.serotonin.mango.rt.maint.work.WorkItemPriority;
 import org.apache.commons.lang3.StringUtils;
 
 import com.serotonin.timer.AbstractTimer;
@@ -54,7 +55,7 @@ public class Synchronizer<T extends Runnable> {
         if (maxConcurrent <= 0 || tasks.size() <= maxConcurrent) {
             // Start all of the tasks.
             for (TaskWrapper tw : tasks)
-                timer.execute(tw);
+                timer.execute(tw, WorkItemPriority.HIGH + " - " + this.getClass().getName());
             running = tasks;
         }
         else {
@@ -66,7 +67,7 @@ public class Synchronizer<T extends Runnable> {
                 // Start tasks
                 while (running.size() < maxConcurrent && !remaining.isEmpty()) {
                     TaskWrapper tw = remaining.remove(remaining.size() - 1);
-                    timer.execute(tw);
+                    timer.execute(tw, WorkItemPriority.HIGH + " - " +  this.getClass().getName());
                     running.add(tw);
                 }
 

--- a/src/org/scada_lts/mango/service/EventService.java
+++ b/src/org/scada_lts/mango/service/EventService.java
@@ -24,6 +24,7 @@ import com.serotonin.mango.rt.event.EventInstance;
 import com.serotonin.mango.rt.event.type.AuditEventType;
 import com.serotonin.mango.rt.event.type.AuditEventUtils;
 import com.serotonin.mango.rt.event.type.EventType;
+import com.serotonin.mango.rt.maint.work.WorkItemPriority;
 import com.serotonin.mango.vo.User;
 import com.serotonin.mango.vo.UserComment;
 import com.serotonin.mango.vo.event.EventHandlerVO;
@@ -32,7 +33,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.quartz.SchedulerException;
 import org.scada_lts.cache.PendingEventsCache;
-import org.scada_lts.config.ScadaConfig;
 import org.scada_lts.dao.DAO;
 import org.scada_lts.dao.IUserCommentDAO;
 import org.scada_lts.dao.event.EventDAO;
@@ -214,7 +214,8 @@ public class EventService implements MangoEvent {
 			userEvents = Collections.emptyList();
 			addToCache(userId, userEvents);
 			//TODO rewrite to delete relation of seroUtils
-			Common.timer.execute(new UserPendingEventRetriever(userId));
+			UserPendingEventRetriever userPendingEventRetriever = new UserPendingEventRetriever(userId);
+			Common.timer.execute(userPendingEventRetriever, WorkItemPriority.HIGH + " - dataPointId: " + dataPointId + ", userId: " + userId + " - " + userPendingEventRetriever.getClass().getName());
 		}
 		List<EventInstance> list = null;
 		for (EventInstance e : userEvents) {

--- a/src/org/scada_lts/utils/ThreadUtils.java
+++ b/src/org/scada_lts/utils/ThreadUtils.java
@@ -1,0 +1,21 @@
+package org.scada_lts.utils;
+
+import org.scada_lts.config.ScadaConfig;
+
+import java.io.IOException;
+
+public final class ThreadUtils {
+
+    private ThreadUtils() {}
+
+    public static String reduceName(String name) {
+        try {
+            int limit = ScadaConfig.getInstance().getInt("thread.name.additional.length", 0);
+            if(limit == 0)
+                return "";
+            return name.length() > limit ? name.substring(0, limit) + ".." : name;
+        } catch (IOException e) {
+            return "";
+        }
+    }
+}

--- a/src/org/scada_lts/web/mvc/api/ScheduledWorkItemInfoApiService.java
+++ b/src/org/scada_lts/web/mvc/api/ScheduledWorkItemInfoApiService.java
@@ -30,6 +30,13 @@ public class ScheduledWorkItemInfoApiService {
                 .collect(Collectors.toList());
     }
 
+    public List<TimerTaskState> getScheduledWorkItemsStates(HttpServletRequest request) {
+        checkIfNonAdminThenUnauthorized(request);
+        return Common.timer.getTasks().stream()
+                .map(a -> TimerTaskState.stateOf(a))
+                .collect(Collectors.toList());
+    }
+
     public Map<String, Long> getScheduledWorkItemsGroupByClassNameCount(HttpServletRequest request) {
         checkIfNonAdminThenUnauthorized(request);
         return Common.timer.getTasks().stream()
@@ -40,7 +47,7 @@ public class ScheduledWorkItemInfoApiService {
         checkIfNonAdminThenUnauthorized(request);
         return Common.timer.getTasks().stream()
                 .map(ScheduledWorkItem::new)
-                .collect(Collectors.groupingBy(a -> a.getClass().getName(), Collectors.toList()));
+                .collect(Collectors.groupingBy(ScheduledWorkItem::getClassName, Collectors.toList()));
     }
 
     public Map<String, Long> getScheduledWorkItemsGroupByClassNameCount(HttpServletRequest request, TimerTaskState state) {
@@ -55,6 +62,6 @@ public class ScheduledWorkItemInfoApiService {
         return Common.timer.getTasks().stream()
                 .filter(a -> TimerTaskState.stateOf(a) == state)
                 .map(ScheduledWorkItem::new)
-                .collect(Collectors.groupingBy(a -> a.getClass().getName(), Collectors.toList()));
+                .collect(Collectors.groupingBy(ScheduledWorkItem::getClassName, Collectors.toList()));
     }
 }

--- a/src/org/scada_lts/web/mvc/api/StateThreadInfoApiService.java
+++ b/src/org/scada_lts/web/mvc/api/StateThreadInfoApiService.java
@@ -44,24 +44,13 @@ public class StateThreadInfoApiService {
         }
     }
 
-    public Long getThreadsCountForState(Thread.State state, HttpServletRequest request) {
-        checkIfNonAdminThenUnauthorized(request);
-        try {
-            Map<Value, Long> map = groupByAndSort(getThreadStack(), groupByStatesCounting(),
-                    Map.Entry.comparingByValue(Comparator.reverseOrder()));
-            Long result = map.get(new Value(state.name()));
-            return result == null ? 0 : result;
-        } catch (Exception e) {
-            throw new InternalServerErrorException(e, request.getRequestURI());
-        }
-    }
-
     public List<Value> getThreadClassesForState(Thread.State state, HttpServletRequest request) {
         checkIfNonAdminThenUnauthorized(request);
         try {
             Map<Value, List<Value>> map = groupByAndSort(getThreadStack(), groupByStatesClass(),
                     Comparator.comparing(entry -> entry.getValue().size(), Comparator.reverseOrder()));
-            return map.get(new Value(state.name()));
+            List<Value> response = map.get(new Value(state.name()));
+            return response == null ? new ArrayList<>() :  response;
         } catch (Exception e) {
             throw new InternalServerErrorException(e, request.getRequestURI());
         }
@@ -72,7 +61,8 @@ public class StateThreadInfoApiService {
         try {
             Map<Value, List<Value>> map = groupByAndSort(getThreadStack(), groupByStatesName(),
                     Comparator.comparing(entry -> entry.getValue().size(), Comparator.reverseOrder()));
-            return map.get(new Value(state.name()));
+            List<Value> response = map.get(new Value(state.name()));
+            return response == null ? new ArrayList<>() :  response;
         } catch (Exception e) {
             throw new InternalServerErrorException(e, request.getRequestURI());
         }

--- a/src/org/scada_lts/web/mvc/api/ThreadInfoAPI.java
+++ b/src/org/scada_lts/web/mvc/api/ThreadInfoAPI.java
@@ -1,6 +1,7 @@
 package org.scada_lts.web.mvc.api;
 
 import org.scada_lts.web.mvc.api.json.ThreadInfo;
+import org.scada_lts.web.mvc.api.json.ThreadInfoList;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,143 +20,115 @@ import static org.scada_lts.utils.ThreadInfoApiUtils.*;
 public class ThreadInfoAPI {
 
     private final ThreadInfoApiService threadInfoApiService;
+    private final StateThreadInfoApiService stateThreadInfoApiService;
 
-    public ThreadInfoAPI(ThreadInfoApiService threadInfoApiService) {
+    public ThreadInfoAPI(ThreadInfoApiService threadInfoApiService, StateThreadInfoApiService stateThreadInfoApiService) {
         this.threadInfoApiService = threadInfoApiService;
+        this.stateThreadInfoApiService = stateThreadInfoApiService;
     }
 
-    @GetMapping(value = "/")
-    public ResponseEntity<List<ThreadInfo>> getThreads(HttpServletRequest request) {
+    @GetMapping(value = "")
+    public ResponseEntity<ThreadInfoList<ThreadInfo>> getThreads(HttpServletRequest request) {
         List<ThreadInfo> response = threadInfoApiService.getThreads(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/stack/")
-    public ResponseEntity<List<ThreadInfo.StackInfo[]>> getStackTraceElements(HttpServletRequest request) {
+    @GetMapping(value = "/stack")
+    public ResponseEntity<ThreadInfoList<ThreadInfo.StackInfo[]>> getStackTraceElements(HttpServletRequest request) {
         List<ThreadInfo.StackInfo[]> response = threadInfoApiService.getStackTraceElements(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/names/")
-    public ResponseEntity<List<Value>> getThreadNames(HttpServletRequest request) {
+    @GetMapping(value = "/names")
+    public ResponseEntity<ThreadInfoList<Value>> getThreadNames(HttpServletRequest request) {
         List<Value> response = threadInfoApiService.getThreadNames(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/count/")
+    @GetMapping(value = "/classes")
+    public ResponseEntity<ThreadInfoList<Value>> getThreadClasses(HttpServletRequest request) {
+        List<Value> response = threadInfoApiService.getThreadClasses(request);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
+    }
+
+    @GetMapping(value = "/group-by/classes/count")
     public ResponseEntity<Map<Value, Long>> getThreadsGroupByClassCount(HttpServletRequest request) {
         Map<Value, Long> response = threadInfoApiService.getThreadsGroupByClassCount(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/thread-stack/")
-    public ResponseEntity<Map<ThreadInfo, ThreadInfo.StackInfo[]>> getThreadsGroupByThreadStack(HttpServletRequest request) {
-        Map<ThreadInfo, ThreadInfo.StackInfo[]> response = threadInfoApiService.getThreadsGroupByThreadStack(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping(value = "/group-by/thread-stack/classes/")
-    public ResponseEntity<Map<ThreadInfo, String[]>> getThreadsGroupByThreadStackClasses(HttpServletRequest request) {
-        Map<ThreadInfo, String[]> response = threadInfoApiService.getThreadsGroupByThreadStackClasses(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping(value = "/group-by/thread-stack/count/")
-    public ResponseEntity<Map<ThreadInfo, Integer>> getThreadsGroupByThreadStackCount(HttpServletRequest request) {
-        Map<ThreadInfo, Integer> response = threadInfoApiService.getThreadsGroupByThreadStackCount(request);
-        return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @GetMapping(value = "/group-by/stack-thread/")
+    @GetMapping(value = "/group-by/stack")
     public ResponseEntity<Map<List<Value>, List<ThreadInfo>>> getThreadsGroupByStackThread(HttpServletRequest request) {
         Map<List<Value>, List<ThreadInfo>> response = threadInfoApiService.getThreadsGroupByStackThread(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/stack-thread/classes/")
+    @GetMapping(value = "/group-by/stack/classes")
     public ResponseEntity<Map<List<Value>, List<Value>>> getThreadsGroupByStackThreadClasses(HttpServletRequest request) {
         Map<List<Value>, List<Value>> response = threadInfoApiService.getThreadsGroupByStackThreadClasses(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/stack-thread/names/")
+    @GetMapping(value = "/group-by/stack/names")
     public ResponseEntity<Map<List<Value>, List<Value>>> getThreadsGroupByStackThreadNames(HttpServletRequest request) {
         Map<List<Value>, List<Value>> response = threadInfoApiService.getThreadsGroupByStackThreadNames(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/stack-thread/count/")
+    @GetMapping(value = "/group-by/stack/count")
     public ResponseEntity<Map<List<Value>, Long>> getThreadsGroupByStackThreadCount(HttpServletRequest request) {
         Map<List<Value>, Long> response = threadInfoApiService.getThreadsGroupByStackThreadCount(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @RestController
-    @RequestMapping(path = "/api/threads/states/")
-    public static class StateThreadInfoAPI {
+    @GetMapping(value = "/states")
+    public ResponseEntity<ThreadInfoList<Value>> getStates(HttpServletRequest request) {
+        List<Value> response = stateThreadInfoApiService.getStates(request);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
+    }
 
-        private final StateThreadInfoApiService stateThreadInfoApiService;
+    @GetMapping(value = "/states/{state}")
+    public ResponseEntity<ThreadInfoList<ThreadInfo>> getThreadsForState(@PathVariable(value = "state", required = true) Thread.State state,
+                                                       HttpServletRequest request) {
+        List<ThreadInfo> response = stateThreadInfoApiService.getThreadsForState(state, request);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
+    }
 
-        public StateThreadInfoAPI(StateThreadInfoApiService stateThreadInfoApiService) {
-            this.stateThreadInfoApiService = stateThreadInfoApiService;
-        }
+    @GetMapping(value = "/states/{state}/classes")
+    public ResponseEntity<ThreadInfoList<Value>> getThreadClassesForState(@PathVariable(value = "state", required = true) Thread.State state,
+                                                                HttpServletRequest request) {
+        List<Value> response = stateThreadInfoApiService.getThreadClassesForState(state, request);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
+    }
 
-        @GetMapping(value = "/")
-        public ResponseEntity<List<Value>> getStates(HttpServletRequest request) {
-            List<Value> response = stateThreadInfoApiService.getStates(request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
+    @GetMapping(value = "/states/{state}/names")
+    public ResponseEntity<ThreadInfoList<Value>> getThreadNamesForState(@PathVariable(value = "state", required = true) Thread.State state,
+                                                              HttpServletRequest request) {
+        List<Value> response = stateThreadInfoApiService.getThreadNamesForState(state, request);
+        return new ResponseEntity<>(new ThreadInfoList<>(response), HttpStatus.OK);
+    }
 
-        @GetMapping(value = "/state/{state}/")
-        public ResponseEntity<List<ThreadInfo>> getThreadsForState(@PathVariable(value = "state", required = true) Thread.State state,
-                                                                   HttpServletRequest request) {
-            List<ThreadInfo> response = stateThreadInfoApiService.getThreadsForState(state, request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
+    @GetMapping(value = "/group-by/states")
+    public ResponseEntity<Map<Value, List<ThreadInfo>>> getThreadsGroupByState(HttpServletRequest request) {
+        Map<Value, List<ThreadInfo>> response = stateThreadInfoApiService.getThreadsGroupByState(request);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 
-        @GetMapping(value = "/state/{state}/count/")
-        public ResponseEntity<Long> getThreadsCountForState(@PathVariable(value = "state", required = true) Thread.State state,
-                                                            HttpServletRequest request) {
-            Long response = stateThreadInfoApiService.getThreadsCountForState(state, request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
+    @GetMapping(value = "/group-by/states/classes")
+    public ResponseEntity<Map<Value, List<Value>>> getThreadClassesGroupByState(HttpServletRequest request) {
+        Map<Value, List<Value>> response = stateThreadInfoApiService.getThreadClassesGroupByState(request);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 
-        @GetMapping(value = "/state/{state}/classes/")
-        public ResponseEntity<List<Value>> getThreadClassesForState(@PathVariable(value = "state", required = true) Thread.State state,
-                                                                    HttpServletRequest request) {
-            List<Value> response = stateThreadInfoApiService.getThreadClassesForState(state, request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
+    @GetMapping(value = "/group-by/states/names")
+    public ResponseEntity<Map<Value, List<Value>>> getThreadNamesGroupByState(HttpServletRequest request) {
+        Map<Value, List<Value>> response = stateThreadInfoApiService.getThreadNamesGroupByState(request);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 
-        @GetMapping(value = "/state/{state}/names/")
-        public ResponseEntity<List<Value>> getThreadNamesForState(@PathVariable(value = "state", required = true) Thread.State state,
-                                                                  HttpServletRequest request) {
-            List<Value> response = stateThreadInfoApiService.getThreadNamesForState(state, request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
-
-        @GetMapping(value = "/group-by/")
-        public ResponseEntity<Map<Value, List<ThreadInfo>>> getThreadsGroupByState(HttpServletRequest request) {
-            Map<Value, List<ThreadInfo>> response = stateThreadInfoApiService.getThreadsGroupByState(request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
-
-        @GetMapping(value = "/group-by/classes/")
-        public ResponseEntity<Map<Value, List<Value>>> getThreadClassesGroupByState(HttpServletRequest request) {
-            Map<Value, List<Value>> response = stateThreadInfoApiService.getThreadClassesGroupByState(request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
-
-        @GetMapping(value = "/group-by/names/")
-        public ResponseEntity<Map<Value, List<Value>>> getThreadNamesGroupByState(HttpServletRequest request) {
-            Map<Value, List<Value>> response = stateThreadInfoApiService.getThreadNamesGroupByState(request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
-
-        @GetMapping(value = "/group-by/count/")
-        public ResponseEntity<Map<Value, Long>> getThreadsCountGroupByState(HttpServletRequest request) {
-            Map<Value, Long> response = stateThreadInfoApiService.getThreadsCountGroupByState(request);
-            return new ResponseEntity<>(response, HttpStatus.OK);
-        }
+    @GetMapping(value = "/group-by/states/count")
+    public ResponseEntity<Map<Value, Long>> getThreadsCountGroupByState(HttpServletRequest request) {
+        Map<Value, Long> response = stateThreadInfoApiService.getThreadsCountGroupByState(request);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/src/org/scada_lts/web/mvc/api/ThreadInfoApiService.java
+++ b/src/org/scada_lts/web/mvc/api/ThreadInfoApiService.java
@@ -56,54 +56,25 @@ public class ThreadInfoApiService {
         }
     }
 
+    public List<Value> getThreadClasses(HttpServletRequest request) {
+        checkIfNonAdminThenUnauthorized(request);
+        try {
+            return getThreadStack().keySet().stream()
+                    .map(a -> a.getClass().getName())
+                    .map(Value::new)
+                    .sorted(Comparator.comparing(Value::getValue))
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            throw new InternalServerErrorException(e, request.getRequestURI());
+        }
+    }
+
     public Map<Value, Long> getThreadsGroupByClassCount(HttpServletRequest request) {
         checkIfNonAdminThenUnauthorized(request);
         try {
             return groupByAndSort(getThreadStack(),
                     Collectors.groupingBy(thread -> new Value(thread.getKey().getClass().getName()), Collectors.counting()),
                     Map.Entry.comparingByValue(Comparator.reverseOrder()));
-        } catch (Exception e) {
-            throw new InternalServerErrorException(e, request.getRequestURI());
-        }
-    }
-
-    public Map<ThreadInfo, ThreadInfo.StackInfo[]> getThreadsGroupByThreadStack(HttpServletRequest request) {
-        checkIfNonAdminThenUnauthorized(request);
-        try {
-            return sorted(getThreadStack().entrySet().stream()
-                    .collect(Collectors
-                            .toMap(entry -> new ThreadInfo(entry.getKey()), entry ->
-                                    Stream.of(entry.getValue())
-                                            .map(ThreadInfo.StackInfo::new)
-                                            .toArray(ThreadInfo.StackInfo[]::new))
-                    ), Comparator.comparing(entry -> entry.getValue().length, Comparator.reverseOrder()));
-        } catch (Exception e) {
-            throw new InternalServerErrorException(e, request.getRequestURI());
-        }
-    }
-
-    public Map<ThreadInfo, String[]> getThreadsGroupByThreadStackClasses(HttpServletRequest request) {
-        checkIfNonAdminThenUnauthorized(request);
-        try {
-            return sorted(getThreadStack().entrySet().stream()
-                    .collect(Collectors
-                            .toMap(entry -> new ThreadInfo(entry.getKey()), entry ->
-                                    Stream.of(entry.getValue())
-                                            .map(ThreadInfo.StackInfo::new)
-                                            .map(ThreadInfo.StackInfo::getClassName)
-                                            .toArray(String[]::new))
-                    ), Comparator.comparing(entry -> entry.getValue().length, Comparator.reverseOrder()));
-        } catch (Exception e) {
-            throw new InternalServerErrorException(e, request.getRequestURI());
-        }
-    }
-
-    public Map<ThreadInfo, Integer> getThreadsGroupByThreadStackCount(HttpServletRequest request) {
-        checkIfNonAdminThenUnauthorized(request);
-        try {
-            return sorted(getThreadStack().entrySet().stream().collect(Collectors
-                            .toMap(entry -> new ThreadInfo(entry.getKey()), entry -> entry.getValue().length)),
-                    Comparator.comparing(entry -> entry.getValue(), Comparator.reverseOrder()));
         } catch (Exception e) {
             throw new InternalServerErrorException(e, request.getRequestURI());
         }

--- a/src/org/scada_lts/web/mvc/api/WorkItemInfoAPI.java
+++ b/src/org/scada_lts/web/mvc/api/WorkItemInfoAPI.java
@@ -24,153 +24,153 @@ public class WorkItemInfoAPI {
         this.workItemInfoApiService = workItemInfoApiService;
     }
 
-    @GetMapping(value = "/")
+    @GetMapping(value = "")
     public ResponseEntity<WorkItemInfoList> getNotExecutedWorkItems(HttpServletRequest request) {
         List<WorkItemInfo> response = workItemInfoApiService.getNotExecutedWorkItems(request);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/")
+    @GetMapping(value = "/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getNotExecutedWorkItemsGroupBy(HttpServletRequest request) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getNotExecutedWorkItemsGroupBy(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/group-by/count/")
-    public ResponseEntity<Map<String, Long>> getNotExecutedWorkItemsGroupByCount(HttpServletRequest request) {
-        Map<String, Long> response = workItemInfoApiService.getNotExecutedWorkItemsGroupByCount(request);
+    @GetMapping(value = "/group-by-classes/count")
+    public ResponseEntity<Map<String, Long>> getNotExecutedWorkItemsGroupByClassName(HttpServletRequest request) {
+        Map<String, Long> response = workItemInfoApiService.getNotExecutedWorkItemsGroupByClassName(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/executed/")
+    @GetMapping(value = "/executed")
     public ResponseEntity<WorkItemInfoList> getExecutedWorkItems(HttpServletRequest request) {
         List<WorkItemInfo> response = workItemInfoApiService.getExecutedWorkItems(request);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/executed/group-by/")
+    @GetMapping(value = "/executed/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedWorkItemsGroupBy(HttpServletRequest request) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedWorkItemsGroupBy(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/executed/group-by/count/")
-    public ResponseEntity<Map<String, Long>> getExecutedWorkItemsGroupByCount(HttpServletRequest request) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedWorkItemsGroupByCount(request);
+    @GetMapping(value = "/executed/group-by-classes/count")
+    public ResponseEntity<Map<String, Long>> getExecutedWorkItemsGroupByClassName(HttpServletRequest request) {
+        Map<String, Long> response = workItemInfoApiService.getExecutedWorkItemsGroupByClassName(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/success/")
+    @GetMapping(value = "/success")
     public ResponseEntity<WorkItemInfoList> getExecutedSuccessWorkItems(HttpServletRequest request) {
         List<WorkItemInfo> response = workItemInfoApiService.getExecutedSuccessWorkItems(request);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/success/group-by/")
+    @GetMapping(value = "/success/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedSuccessWorkItemsGroupBy(HttpServletRequest request) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedSuccessWorkItemsGroupBy(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/success/group-by/count/")
+    @GetMapping(value = "/success/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getExecutedSuccessWorkItemsGroupByCount(HttpServletRequest request) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedSuccessWorkItemsGroupByCount(request);
+        Map<String, Long> response = workItemInfoApiService.getExecutedSuccessWorkItemsGroupByClassName(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/failed/")
+    @GetMapping(value = "/failed")
     public ResponseEntity<WorkItemInfoList> getExecutedFailWorkItems(HttpServletRequest request) {
         List<WorkItemInfo> response = workItemInfoApiService.getExecutedFailedWorkItems(request);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/failed/group-by/")
+    @GetMapping(value = "/failed/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedFailWorkItemsGroupBy(HttpServletRequest request) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedFailedWorkItemsGroupBy(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/failed/group-by/count/")
+    @GetMapping(value = "/failed/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getExecutedFailWorkItemsGroupByCount(HttpServletRequest request) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedFailedWorkItemsGroupByCount(request);
+        Map<String, Long> response = workItemInfoApiService.getExecutedFailedWorkItemsGroupByClassName(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/running/")
+    @GetMapping(value = "/running")
     public ResponseEntity<WorkItemInfoList> getRunningWorkItems(HttpServletRequest request) {
         List<WorkItemInfo> response = workItemInfoApiService.getRunningWorkItems(request);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/running/group-by/")
+    @GetMapping(value = "/running/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getRunningFailWorkItemsGroupBy(HttpServletRequest request) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getRunningWorkItemsGroupBy(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/running/group-by/count/")
+    @GetMapping(value = "/running/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getRunningFailWorkItemsGroupByCount(HttpServletRequest request) {
-        Map<String, Long> response = workItemInfoApiService.getRunningWorkItemsGroupByCount(request);
+        Map<String, Long> response = workItemInfoApiService.getRunningWorkItemsGroupByClassName(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/all/")
+    @GetMapping(value = "/all")
     public ResponseEntity<WorkItemInfoList> getWorkItems(HttpServletRequest request) {
         List<WorkItemInfo> response = workItemInfoApiService.getWorkItems(request);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/all/group-by/")
+    @GetMapping(value = "/all/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getWorkItemsGroupBy(HttpServletRequest request) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getWorkItemsGroupBy(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/all/group-by/count/")
+    @GetMapping(value = "/all/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getWorkItemsGroupByCount(HttpServletRequest request) {
-        Map<String, Long> response = workItemInfoApiService.getWorkItemsGroupByCount(request);
+        Map<String, Long> response = workItemInfoApiService.getWorkItemsGroupByClassName(request);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/longer/{executedMs}/")
+    @GetMapping(value = "/longer/{executedMs}")
     public ResponseEntity<WorkItemInfoList> getExecutedLongerWorkItems(HttpServletRequest request,
                                                                        @PathVariable("executedMs") int executedMs) {
         List<WorkItemInfo> response = workItemInfoApiService.getExecutedLongerWorkItems(request, executedMs, false);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/longer/{executedMs}/group-by/")
+    @GetMapping(value = "/longer/{executedMs}/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedLongerWorkItemsGroupBy(HttpServletRequest request,
                                                                                @PathVariable("executedMs") int executedMs) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedLongerWorkItemsGroupBy(request, executedMs, false);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/longer/{executedMs}/group-by/count/")
+    @GetMapping(value = "/longer/{executedMs}/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getExecutedLongerWorkItemsGroupByCount(HttpServletRequest request,
                                                                                @PathVariable("executedMs") int executedMs) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedLongerWorkItemsGroupByCount(request, executedMs, false);
+        Map<String, Long> response = workItemInfoApiService.getExecutedLongerWorkItemsGroupByClassName(request, executedMs, false);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/longer/{executedMs}/history/")
+    @GetMapping(value = "/history/longer/{executedMs}")
     public ResponseEntity<WorkItemInfoList> getExecutedLongerWorkItemsHistory(HttpServletRequest request,
                                                                               @PathVariable("executedMs") int executedMs) {
         List<WorkItemInfo> response = workItemInfoApiService.getExecutedLongerWorkItems(request, executedMs, true);
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/longer/{executedMs}/history/group-by/")
+    @GetMapping(value = "/history/longer/{executedMs}/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedLongerWorkItemsGroupByHistory(HttpServletRequest request,
                                                                                                     @PathVariable("executedMs") int executedMs) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedLongerWorkItemsGroupBy(request, executedMs, true);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/longer/{executedMs}/history/group-by/count/")
+    @GetMapping(value = "/history/longer/{executedMs}/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getExecutedLongerWorkItemsGroupByCountHistory(HttpServletRequest request,
                                                                                     @PathVariable("executedMs") int executedMs) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedLongerWorkItemsGroupByCount(request, executedMs, true);
+        Map<String, Long> response = workItemInfoApiService.getExecutedLongerWorkItemsGroupByClassName(request, executedMs, true);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -181,17 +181,17 @@ public class WorkItemInfoAPI {
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/less/{executedMs}/group-by/")
+    @GetMapping(value = "/less/{executedMs}/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedLessWorkItemsGroupBy(HttpServletRequest request,
                                                                              @PathVariable("executedMs") int executedMs) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedLessWorkItemsGroupBy(request, executedMs);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/less/{executedMs}/group-by/count/")
+    @GetMapping(value = "/less/{executedMs}/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getExecutedLessWorkItemsGroupByCount(HttpServletRequest request,
                                                                              @PathVariable("executedMs") int executedMs) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedLessWorkItemsGroupByCount(request, executedMs);
+        Map<String, Long> response = workItemInfoApiService.getExecutedLessWorkItemsGroupByClassName(request, executedMs);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -202,17 +202,17 @@ public class WorkItemInfoAPI {
         return new ResponseEntity<>(new WorkItemInfoList(response), HttpStatus.OK);
     }
 
-    @GetMapping(value = "/priority/{priority}/group-by/")
+    @GetMapping(value = "/priority/{priority}/group-by-classes")
     public ResponseEntity<Map<String, List<WorkItemInfo>>> getExecutedLessWorkItemsGroupByPriority(HttpServletRequest request,
                                                                                           @PathVariable("priority") WorkItemPriority priority) {
         Map<String, List<WorkItemInfo>> response = workItemInfoApiService.getExecutedLessWorkItemsGroupByPriority(request, priority);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/priority/{priority}/group-by/count/")
+    @GetMapping(value = "/priority/{priority}/group-by-classes/count")
     public ResponseEntity<Map<String, Long>> getExecutedLessWorkItemsGroupByPriorityCount(HttpServletRequest request,
                                                                                      @PathVariable("priority") WorkItemPriority priority) {
-        Map<String, Long> response = workItemInfoApiService.getExecutedLessWorkItemsGroupByPriorityCount(request, priority);
+        Map<String, Long> response = workItemInfoApiService.getExecutedLessWorkItemsGroupByPriorityClassName(request, priority);
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -227,38 +227,44 @@ public class WorkItemInfoAPI {
         }
 
         @GetMapping(value = "/")
-        public ResponseEntity<ScheduledWorkItemInfoList> getScheduledWorkItems(HttpServletRequest request) {
+        public ResponseEntity<ScheduledWorkItemInfoList<ScheduledWorkItem>> getScheduledWorkItems(HttpServletRequest request) {
             List<ScheduledWorkItem> response = scheduledWorkItemInfoApiService.getScheduledWorkItems(request);
-            return new ResponseEntity<>(new ScheduledWorkItemInfoList(response), HttpStatus.OK);
+            return new ResponseEntity<>(new ScheduledWorkItemInfoList<>(response), HttpStatus.OK);
         }
 
-        @GetMapping(value = "/group-by/")
+        @GetMapping(value = "/group-by-classes")
         public ResponseEntity<Map<String, List<ScheduledWorkItem>>> getScheduledWorkItemsGroupByClassName(HttpServletRequest request) {
             Map<String, List<ScheduledWorkItem>> response = scheduledWorkItemInfoApiService.getScheduledWorkItemsGroupByClassName(request);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
-        @GetMapping(value = "/group-by/count/")
+        @GetMapping(value = "/group-by-classes/count")
         public ResponseEntity<Map<String, Long>> getScheduledWorkItemsGroupByClassNameCount(HttpServletRequest request) {
             Map<String, Long> response = scheduledWorkItemInfoApiService.getScheduledWorkItemsGroupByClassNameCount(request);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
-        @GetMapping(value = "/state/{state}/")
-        public ResponseEntity<ScheduledWorkItemInfoList> getScheduledWorkItems(HttpServletRequest request,
-                                                                               @PathVariable("state") TimerTaskState state) {
-            List<ScheduledWorkItem> response = scheduledWorkItemInfoApiService.getScheduledWorkItems(request, state);
-            return new ResponseEntity<>(new ScheduledWorkItemInfoList(response), HttpStatus.OK);
+        @GetMapping(value = "/states")
+        public ResponseEntity<ScheduledWorkItemInfoList<TimerTaskState>> getScheduledWorkItemsStates(HttpServletRequest request) {
+            List<TimerTaskState> response = scheduledWorkItemInfoApiService.getScheduledWorkItemsStates(request);
+            return new ResponseEntity<>(new ScheduledWorkItemInfoList<>(response), HttpStatus.OK);
         }
 
-        @GetMapping(value = "/state/{state}/group-by/")
+        @GetMapping(value = "/states/{state}")
+        public ResponseEntity<ScheduledWorkItemInfoList<ScheduledWorkItem>> getScheduledWorkItems(HttpServletRequest request,
+                                                                               @PathVariable("state") TimerTaskState state) {
+            List<ScheduledWorkItem> response = scheduledWorkItemInfoApiService.getScheduledWorkItems(request, state);
+            return new ResponseEntity<>(new ScheduledWorkItemInfoList<>(response), HttpStatus.OK);
+        }
+
+        @GetMapping(value = "/states/{state}/group-by-classes")
         public ResponseEntity<Map<String, List<ScheduledWorkItem>>> getScheduledWorkItemsGroupByClassName(HttpServletRequest request,
                                                                                             @PathVariable("state")TimerTaskState state) {
             Map<String, List<ScheduledWorkItem>> response = scheduledWorkItemInfoApiService.getScheduledWorkItemsGroupByClassName(request, state);
             return new ResponseEntity<>(response, HttpStatus.OK);
         }
 
-        @GetMapping(value = "/state/{state}/group-by/count/")
+        @GetMapping(value = "/states/{state}/group-by-classes/count")
         public ResponseEntity<Map<String, Long>> getScheduledWorkItemsGroupByClassNameCount(HttpServletRequest request,
                                                                                             @PathVariable("state")TimerTaskState state) {
             Map<String, Long> response = scheduledWorkItemInfoApiService.getScheduledWorkItemsGroupByClassNameCount(request, state);

--- a/src/org/scada_lts/web/mvc/api/WorkItemInfoApiService.java
+++ b/src/org/scada_lts/web/mvc/api/WorkItemInfoApiService.java
@@ -59,27 +59,27 @@ public class WorkItemInfoApiService {
                 WorkItemsUtils::getByExecutedLessThan, executedMs);
     }
 
-    public Map<String, Long> getExecutedWorkItemsGroupByCount(HttpServletRequest request) {
+    public Map<String, Long> getExecutedWorkItemsGroupByClassName(HttpServletRequest request) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, WorkItemsUtils::getByExecuted);
     }
 
-    public Map<String, Long> getExecutedSuccessWorkItemsGroupByCount(HttpServletRequest request) {
+    public Map<String, Long> getExecutedSuccessWorkItemsGroupByClassName(HttpServletRequest request) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, WorkItemsUtils::getBySuccess);
     }
 
-    public Map<String, Long> getExecutedFailedWorkItemsGroupByCount(HttpServletRequest request) {
+    public Map<String, Long> getExecutedFailedWorkItemsGroupByClassName(HttpServletRequest request) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, WorkItemsUtils::getByFailed);
     }
 
-    public Map<String, Long> getWorkItemsGroupByCount(HttpServletRequest request) {
+    public Map<String, Long> getWorkItemsGroupByClassName(HttpServletRequest request) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, WorkItemsUtils::getAll);
     }
 
-    public Map<String, Long> getNotExecutedWorkItemsGroupByCount(HttpServletRequest request) {
+    public Map<String, Long> getNotExecutedWorkItemsGroupByClassName(HttpServletRequest request) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, WorkItemsUtils::getByNotExecuted);
     }
 
-    public Map<String, Long> getExecutedLongerWorkItemsGroupByCount(HttpServletRequest request, int executedMs, boolean history) {
+    public Map<String, Long> getExecutedLongerWorkItemsGroupByClassName(HttpServletRequest request, int executedMs, boolean history) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, byExecuteMsComparator(),
                 executed -> {
                     if(history)
@@ -88,18 +88,18 @@ public class WorkItemInfoApiService {
                 }, executedMs);
     }
 
-    public Map<String, Long> getExecutedLessWorkItemsGroupByCount(HttpServletRequest request, int executedMs) {
+    public Map<String, Long> getExecutedLessWorkItemsGroupByClassName(HttpServletRequest request, int executedMs) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, byExecuteMsComparator(),
                 WorkItemsUtils::getByExecutedLessThan, executedMs);
     }
 
-    public Map<String, Long> getExecutedLessWorkItemsGroupByPriorityCount(HttpServletRequest request,
-                                                                     WorkItemPriority priority) {
+    public Map<String, Long> getExecutedLessWorkItemsGroupByPriorityClassName(HttpServletRequest request,
+                                                                              WorkItemPriority priority) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting,
                 byExecuteMsComparator(), WorkItemsUtils::getByPriority, priority);
     }
 
-    public Map<String, Long> getRunningWorkItemsGroupByCount(HttpServletRequest request) {
+    public Map<String, Long> getRunningWorkItemsGroupByClassName(HttpServletRequest request) {
         return get(request, WorkItemInfoApiService::groupByClassNameCounting, WorkItemsUtils::getRunning);
     }
 

--- a/src/org/scada_lts/web/mvc/api/json/ScheduledWorkItemInfoList.java
+++ b/src/org/scada_lts/web/mvc/api/json/ScheduledWorkItemInfoList.java
@@ -2,16 +2,16 @@ package org.scada_lts.web.mvc.api.json;
 
 import java.util.List;
 
-public class ScheduledWorkItemInfoList {
+public class ScheduledWorkItemInfoList<T> {
     private final int size;
-    private final List<ScheduledWorkItem> workItemScheduled;
+    private final List<T> workItemScheduled;
 
-    public ScheduledWorkItemInfoList(List<ScheduledWorkItem> workItemScheduled) {
+    public ScheduledWorkItemInfoList(List<T> workItemScheduled) {
         this.workItemScheduled = workItemScheduled;
         this.size = workItemScheduled.size();
     }
 
-    public List<ScheduledWorkItem> getWorkItemScheduled() {
+    public List<T> getWorkItemScheduled() {
         return workItemScheduled;
     }
 

--- a/src/org/scada_lts/web/mvc/api/json/ThreadInfoList.java
+++ b/src/org/scada_lts/web/mvc/api/json/ThreadInfoList.java
@@ -1,0 +1,24 @@
+package org.scada_lts.web.mvc.api.json;
+
+
+import java.util.List;
+
+public class ThreadInfoList<T> {
+
+    private final int size;
+    private final List<T> threadInfoList;
+
+    public ThreadInfoList(List<T> threadInfoList) {
+        this.threadInfoList = threadInfoList;
+        this.size = threadInfoList.size();
+    }
+
+    public List<T> getThreadInfoList() {
+        return threadInfoList;
+    }
+
+    public int getSize() {
+        return size;
+    }
+}
+

--- a/webapp-resources/env.properties
+++ b/webapp-resources/env.properties
@@ -132,3 +132,4 @@ view.forceFullScreen=false
 view.hideShortcutDisableFullScreen=false
 eventdetector.cache.enabled=true
 event.pending.limit=101
+thread.name.additional.length=255


### PR DESCRIPTION
- Adding the threadName parameter to the data returned by the API, specifying the name of the thread that executed a given work item;
- Naming threads so that you can detect which threads come from the pools: high, medium, low priority;
- Adding the name of the work item that is currently executing to the thread to recognize which work items are executing for a longer time, and to recognize which thread;
- Refactoring the work-items and threads API to make it more logical and easier to use;
- Fixed method in ScheduledWorkItemInfoApiService: getThreadClassesForState, getThreadNamesForState for empty result;
- Added parameter thread.name.additional.length to env.properties 0 - without additional name to thread