### PR TITLE
#2715 Fixed DNP3 Serial data source causing SystemException

### DIFF
--- a/src/br/org/scadabr/rt/dataSource/dnp3/Dnp3DataSource.java
+++ b/src/br/org/scadabr/rt/dataSource/dnp3/Dnp3DataSource.java
@@ -45,10 +45,11 @@ public class Dnp3DataSource extends PollingDataSource {
 			dnp3Master.doPoll();
 			returnToNormal(DATA_SOURCE_EXCEPTION_EVENT, time);
 		} catch (Exception e) {
-			e.printStackTrace();
+			LOG.warn(e.getMessage(), e);
 			raiseEvent(DATA_SOURCE_EXCEPTION_EVENT, time, true,
 					new LocalizableMessage("event.exception2", vo.getName(), e
 							.getMessage()));
+			return;
 		}
 
 		for (DataPointRT dataPoint : dataPoints) {
@@ -85,7 +86,7 @@ public class Dnp3DataSource extends PollingDataSource {
 			raiseEvent(DATA_SOURCE_EXCEPTION_EVENT, new Date().getTime(), true,
 					new LocalizableMessage("event.exception2", vo.getName(), e
 							.getMessage()));
-			e.printStackTrace();
+			LOG.error(e.getMessage(), e);
 		}
 	}
 

--- a/src/com/serotonin/mango/Common.java
+++ b/src/com/serotonin/mango/Common.java
@@ -23,15 +23,13 @@ import java.nio.charset.Charset;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.ResourceBundle;
-import java.util.Arrays;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 
 import com.serotonin.mango.web.mvc.controller.ScadaLocaleUtils;
+import gnu.io.CommPortIdentifier;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
@@ -402,6 +400,26 @@ public class Common {
 			}
 		} catch (ParseException e) {
 			throw new ShouldNeverHappenException(e);
+		}
+	}
+
+	public static List<CommPortProxy> getCommPorts()
+			throws CommPortConfigException {
+		try {
+			List<CommPortProxy> ports = new LinkedList<CommPortProxy>();
+			Enumeration<?> portEnum = CommPortIdentifier.getPortIdentifiers();
+			CommPortIdentifier cpid;
+			while (portEnum.hasMoreElements()) {
+				cpid = (CommPortIdentifier) portEnum.nextElement();
+				if (cpid.getPortType() == CommPortIdentifier.PORT_SERIAL)
+					ports.add(new CommPortProxy(cpid));
+			}
+			return ports;
+		} catch (UnsatisfiedLinkError e) {
+			throw new CommPortConfigException(e.getMessage());
+		} catch (NoClassDefFoundError e) {
+			throw new CommPortConfigException(
+					"Comm configuration error. Check that rxtx DLL or libraries have been correctly installed.");
 		}
 	}
 

--- a/src/com/serotonin/mango/web/mvc/controller/DataSourceEditController.java
+++ b/src/com/serotonin/mango/web/mvc/controller/DataSourceEditController.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.serotonin.mango.vo.CommPortProxy;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.ParameterizableViewController;
 
@@ -93,7 +94,7 @@ public class DataSourceEditController extends ParameterizableViewController {
 
         // Reference data
         try {
-            model.put("commPorts", Common.getSerialPorts());
+            model.put("commPorts", getPorts(dataSourceVO));
         }
         catch (CommPortConfigException e) {
             model.put("commPortError", e.getMessage());
@@ -113,5 +114,13 @@ public class DataSourceEditController extends ParameterizableViewController {
         model.put("analogPoints", analogPoints);
 
         return new ModelAndView(getViewName(), model);
+    }
+
+    private static List<CommPortProxy>  getPorts(DataSourceVO<?> dataSource) throws CommPortConfigException {
+        if(DataSourceVO.Type.MODBUS_SERIAL == dataSource.getType()) {
+            return Common.getSerialPorts();
+        } else {
+            return Common.getCommPorts();
+        }
     }
 }


### PR DESCRIPTION
- Dnp3DataSource.doPoll - using the log4j2 library to log, warn level; if the master has not connected, there is no point in trying to update the points
- DNP3Master.initSerial - catching an error regarding the old rxtx library not being configured to support serial ports, this resulted in a complete system crash preventing any user action;
- DNP3Master.doPoll - small refactoring;
- DNP3Master.terminate - catching exception for DNPUser.stop;
- DataSourceEditController - restricting the use of the new jSerialComm library to Serial Modbus Data Source;
- Common - restoring the old method that retrieves the list of serial ports available in the system;