### PR TITLE
#2112 Event comments in DataPointDetails are not working  -

### DIFF
--- a/src/org/scada_lts/mango/service/EventService.java
+++ b/src/org/scada_lts/mango/service/EventService.java
@@ -220,7 +220,9 @@ public class EventService implements MangoEvent {
 	@Override
 	public List<EventInstance> getEventsForDataPoint(int dataPointId, int userId) {
 		int limit = systemSettingsService.getMiscSettings().getEventPendingLimit();
-		return eventDAO.getEventsForDataPointLimit(dataPointId, userId, limit);
+		List<EventInstance> lst = eventDAO.getEventsForDataPointLimit(dataPointId, userId, limit);
+		attachRelationInfo(lst);
+		return lst;
 	}
 
 	@Override


### PR DESCRIPTION
* completing comments for the list of events retrieved by the EventService.getEventsForDataPoint method