### PR TITLE
#2770 Fixed minimum/maximum calculate in Meta Data Point script - 'de…

### DIFF
--- a/src/org/scada_lts/dao/pointvalues/PointValueDAO.java
+++ b/src/org/scada_lts/dao/pointvalues/PointValueDAO.java
@@ -209,7 +209,7 @@ public class PointValueDAO implements GenericDaoCR<PointValue> {
 	public static final String POINT_VALUE_FILTER_BEFORE_TIME_STAMP_BASE_ON_DATA_POINT_ID = " "
 			+ "pv."+COLUMN_NAME_DATA_POINT_ID+"=? and "
 			+ "pv."+COLUMN_NAME_TIME_STAMP+"<? "
-			+ "order by pv."+COLUMN_NAME_TIME_STAMP;
+			+ "order by pv."+COLUMN_NAME_TIME_STAMP+" desc";
 	
 	public static final String POINT_VALUE_FILTER_AT_TIME_STAMP_BASE_ON_DATA_POINT_ID = " "
 			+ "pv."+COLUMN_NAME_DATA_POINT_ID+"=? and "


### PR DESCRIPTION
…sc' was added to the PointValueDAO.POINT_VALUE_FILTER_BEFORE_TIME_STAMP_BASE_ON_DATA_POINT_ID query at the end, now the start value used to calculate statistics should be correct and should not result in incorrect statistics calculation;