### PR TITLE
fix/#2722_MQTT_data_source_stops_communicating_with_broker_after_PC_restarts

### DIFF
--- a/WebContent/WEB-INF/jsp/dataSourceEdit/editMqtt.jsp
+++ b/WebContent/WEB-INF/jsp/dataSourceEdit/editMqtt.jsp
@@ -35,7 +35,13 @@
         dataSourceToSave.cleanSession=$get("cleanSession");
         dataSourceToSave.brokerMode=$get("brokerMode");
 
-        DataSourceEditDwr.saveMqttDataSource(dataSourceToSave, saveDataSourceCB);
+        if(!isValid(dataSourceToSave.updateAttempts)) {
+          $set("updateAttemptsMessage", $get("updateAttemptsForm") + " - Incorrect input data type");
+        }
+        else {
+          $set("updateAttemptsMessage", "");
+          DataSourceEditDwr.saveMqttDataSource(dataSourceToSave, saveDataSourceCB);
+        }
     }
   function editPointCBImpl(locator) {
         $set("settable", locator.settable);
@@ -60,6 +66,13 @@
     DataSourceEditDwr.saveMqttPointLocator(
     currentPoint.id, $get("xid"), $get("name"), locator, savePointCB);
     }
+  function isValid(value) {
+    return value == "" || isPositiveInt(value);
+    }
+
+  function isPositiveInt(value) {
+    return isInt32(value) && value >= 0;
+    }
 </script>
 
 
@@ -76,8 +89,9 @@
     </td>
   </tr>
   <tr>
-    <td class="formLabelRequired"><fmt:message key="dsEdit.messaging.updateAttempts"/></td>
+    <td id="updateAttemptsForm" class="formLabelRequired"><fmt:message key="dsEdit.messaging.updateAttempts"/></td>
     <td class="formField"><input type="text" id="updateAttempts" value="${dataSource.updateAttempts}"/></td>
+    <span id="updateAttemptsMessage" class="formError"></span>
   </tr>
   <tr>
     <td class="formLabelRequired"><fmt:message key="dsEdit.serverHost"/></td>

--- a/src/org/scada_lts/ds/messaging/channel/MessagingChannelsImpl.java
+++ b/src/org/scada_lts/ds/messaging/channel/MessagingChannelsImpl.java
@@ -43,6 +43,9 @@ class MessagingChannelsImpl implements MessagingChannels {
     @Override
     public void initChannel(DataPointRT dataPoint, Supplier<MessagingChannel> create) {
         try {
+            if(getChannel(dataPoint).isPresent() && !getChannel(dataPoint).get().isOpen()) {
+                removeChannel(dataPoint);
+            }
             getChannel(dataPoint).orElseGet(() -> operationChannels.createChannelIfNotExists(dataPoint.getId(), a -> create.get()));
         } catch (MessagingChannelException e) {
             throw e;

--- a/src/org/scada_lts/ds/messaging/channel/MessagingChannelsImpl.java
+++ b/src/org/scada_lts/ds/messaging/channel/MessagingChannelsImpl.java
@@ -43,9 +43,7 @@ class MessagingChannelsImpl implements MessagingChannels {
     @Override
     public void initChannel(DataPointRT dataPoint, Supplier<MessagingChannel> create) {
         try {
-            if(getChannel(dataPoint).isPresent() && !getChannel(dataPoint).get().isOpen()) {
-                removeChannel(dataPoint);
-            }
+            getChannel(dataPoint).filter(channel -> !channel.isOpen()).ifPresent(channel -> removeChannel(dataPoint));
             getChannel(dataPoint).orElseGet(() -> operationChannels.createChannelIfNotExists(dataPoint.getId(), a -> create.get()));
         } catch (MessagingChannelException e) {
             throw e;

--- a/src/org/scada_lts/ds/messaging/protocol/mqtt/MqttDataSourceVO.java
+++ b/src/org/scada_lts/ds/messaging/protocol/mqtt/MqttDataSourceVO.java
@@ -111,7 +111,7 @@ public class MqttDataSourceVO extends DataSourceVO<MqttDataSourceVO> implements 
         if (serverPortNumber < 0) {
             response.addContextualMessage("serverPortNumber","validate.invalidValue");
         }
-        if (updateAttempts < 0 || updateAttempts > 10) {
+        if (updateAttempts < 0) {
             response.addContextualMessage("updateAttempts", "validate.updateAttempts");
         }
 


### PR DESCRIPTION
Added:

- In MessagingChannelsImpl.java if condition that removes old channels before creating new one
- In MqttDataSourceVO.java changed validation for updateAttempts, now it only checks for negative numbers
- In editMqtt.jsp, validation that checks if given update attempts IsInt32