### PR TITLE
Fix/ Risk of duplicate range formats when applying format from another datapoint #2769

### DIFF
--- a/WebContent/WEB-INF/jsp/dataPointEdit.jsp
+++ b/WebContent/WEB-INF/jsp/dataPointEdit.jsp
@@ -223,12 +223,22 @@
                        if (properties.eventTextRenderer.def.name == "eventTextRendererRange") {
 
                            if (checkGetAlertError()) {
+                               let thisEventRangeValues = this.eventTextRendererEditor.getRangeEventValues();
                                try {
                                    var alert_old = alert;
                                    alert = function (message) {
                                        console.log(message);
                                    }
                                    for (var range in properties.eventTextRenderer.rangeEventValues) {
+                                       for (let i = 0; i < thisEventRangeValues.length; i++){
+                                            if(
+                                                parseFloat(thisEventRangeValues[i].from) === parseFloat(properties.eventTextRenderer.rangeEventValues[range].from) &&
+                                                parseFloat(thisEventRangeValues[i].to) === parseFloat(properties.eventTextRenderer.rangeEventValues[range].to))
+                                           {
+                                               eventTextRendererEditor.removeRangeEventValue(parseFloat(properties.eventTextRenderer.rangeEventValues[range].from),
+                                                   parseFloat(properties.eventTextRenderer.rangeEventValues[range].to))
+                                           }
+                                       }
                                        eventTextRendererEditor.addRangeEventValue(
                                            String( properties.eventTextRenderer.rangeEventValues[range].from ),
                                            String( properties.eventTextRenderer.rangeEventValues[range].to ),

--- a/WebContent/WEB-INF/jsp/dataPointEdit.jsp
+++ b/WebContent/WEB-INF/jsp/dataPointEdit.jsp
@@ -319,11 +319,20 @@
 
                         if (checkGetAlertError()) {
                             try {
+                                let thisRangeValues = this.textRendererEditor.getRangeValues();
                                 var alert_old = alert;
                                 alert = function (message) {
                                     console.log(message);
                                 }
                                 for (var range in properties.textRenderer.rangeValues) {
+                                    for (let i = 0; i < thisRangeValues.length; i++) {
+                                        if (
+                                            parseFloat(thisRangeValues[i].from) === parseFloat(properties.textRenderer.rangeValues[range].from) &&
+                                            parseFloat(thisRangeValues[i].to) === parseFloat(properties.textRenderer.rangeValues[range].to))
+                                        {
+                                            textRendererEditor.removeRangeValue(parseFloat(properties.textRenderer.rangeValues[range].from), parseFloat(properties.textRenderer.rangeValues[range].to));
+                                        }
+                                    }
                                     textRendererEditor.addRangeValue(
                                         String( properties.textRenderer.rangeValues[range].from ),
                                         String( properties.textRenderer.rangeValues[range].to ),

--- a/WebContent/WEB-INF/jsp/pointEdit/eventTextRenderer.jsp
+++ b/WebContent/WEB-INF/jsp/pointEdit/eventTextRenderer.jsp
@@ -312,6 +312,9 @@
         }
       ], null);
     };
+    this.getRangeEventValues = function(){
+        return rangeEventValues;
+    }
   }
   var eventTextRendererEditor = new EventTextRendererEditor();
   dojo.addOnLoad(eventTextRendererEditor, "init");

--- a/WebContent/WEB-INF/jsp/pointEdit/textRenderer.jsp
+++ b/WebContent/WEB-INF/jsp/pointEdit/textRenderer.jsp
@@ -435,6 +435,9 @@
           dojo.widget.byId("textRendererBinaryOneColour").selectedColour = colour;
           $("textRendererBinaryOne").style.color = colour;
       };
+      this.getRangeValues = function(){
+          return rangeValues;
+      }
   }
   var textRendererEditor = new TextRendererEditor();
   dojo.addOnLoad(textRendererEditor, "init");


### PR DESCRIPTION
Issue: #2769 

Added:
- getRangeValues() method which returns all current range text renderers
- Validation for text renderers when using "Apply new properties basing on", now there should be no duplicates