### PR TITLE
#2528 Datapoint creation box overlaps other boxes and outdated Modbus data type

### DIFF
--- a/WebContent/WEB-INF/jsp/dataSourceEdit/editModbus.jsp
+++ b/WebContent/WEB-INF/jsp/dataSourceEdit/editModbus.jsp
@@ -283,7 +283,9 @@
     <c:set var="dsHelpId" value="modbusIpDS"/>
   </c:when>
 </c:choose>
+<div style="width: 70%">
 <%@ include file="/WEB-INF/jsp/dataSourceEdit/dsHead.jspf" %>
+</div>
         <tr>
           <td class="formLabelRequired"><fmt:message key="dsEdit.updatePeriod"/></td>
           <td class="formField">
@@ -368,7 +370,7 @@
     </div>
     
     <div class="borderDiv marB marR" style="float:left;">
-      <table>
+      <table width="95%">
         <tr><td colspan="2" class="smallTitle"><fmt:message key="dsEdit.modbus.dataTest"/></td></tr>
         
         <tr>
@@ -410,8 +412,8 @@
       </table>
     </div>
     
-    <div class="borderDiv marB" id="locatorTestDiv" style="clear:both;">
-      <table>
+    <div class="borderDiv marB" id="locatorTestDiv" style="clear:both; width: 95%">
+      <table width="95%">
         <tr><td colspan="2" class="smallTitle"><fmt:message key="dsEdit.modbus.locatorTest"/></td></tr>
         
         <tr>
@@ -434,7 +436,7 @@
         <tr>
           <td class="formLabelRequired"><fmt:message key="dsEdit.modbus.modbusDataType"/></td>
           <td class="formField">
-            <select id="test_modbusDataType" onchange="changeDataType('test_')">
+            <select id="test_modbusDataType" onchange="changeDataType('test_')" style="width: 80%">
               <option value="<c:out value="<%= DataType.BINARY %>"/>"><fmt:message key="dsEdit.modbus.modbusDataType.binary"/></option>
               <option value="<c:out value="<%= DataType.TWO_BYTE_INT_UNSIGNED %>"/>"><fmt:message key="dsEdit.modbus.modbusDataType.2bUnsigned"/></option>
               <option value="<c:out value="<%= DataType.TWO_BYTE_INT_SIGNED %>"/>"><fmt:message key="dsEdit.modbus.modbusDataType.2bSigned"/></option>

--- a/WebContent/WEB-INF/tags/pointList.tag
+++ b/WebContent/WEB-INF/tags/pointList.tag
@@ -21,7 +21,7 @@
 <%@tag import="com.serotonin.mango.Common"%>
 <%@attribute name="pointHelpId" required="true"%>
 
-<table cellpadding="0" cellspacing="0" id="pointProperties" style="display:none; width:60%;">
+<table cellpadding="0" cellspacing="5" id="pointProperties" style="display:none; width:70%;">
   <tr>
     <td valign="top">
       <div class="borderDiv marR marB">
@@ -44,7 +44,7 @@
     </td>
 
     <td>
-      <div id="pointDetails" class="borderDiv marB" style="display: none;">
+      <div id="pointDetails" class="borderDiv marB" style="display: none; width: 30%;position: fixed; right: 0;">
         <table width="100%">
           <tr>
             <td>


### PR DESCRIPTION
Added:
- Styles for editModbus.jsp and pointList.tag for containers so no they are able to readjust in case of small web browser size

To test:
- Different views than Modbus editing view to see if pointList.tag is working correctly and no visual bugs are occuring