### PR TITLE
#2096 Some SVG images are not displayed correctly in edit view:

### DIFF
--- a/WebContent/resources/view.js
+++ b/WebContent/resources/view.js
@@ -563,7 +563,7 @@ mango.view.graphic.HorizontalLevel.setValue = function(viewComponentId, value) {
 async function loadDefaultSizeContainer(fileUrl, containerId) {
     const notFoundFile = await isNotFoundFile(fileUrl);
     const container = document.getElementById(containerId);
-    if(notFoundFile) {
+    if(notFoundFile || fileUrl.endsWith('.svg')) {
         container.width=1920;
         container.height=1080;
     } else {

--- a/src/org/scada_lts/dao/SystemSettingsDAO.java
+++ b/src/org/scada_lts/dao/SystemSettingsDAO.java
@@ -42,9 +42,6 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
-import static org.scada_lts.utils.SystemSettingsUtils.WEB_RESOURCE_GRAPHICS_PATH;
-import static org.scada_lts.utils.SystemSettingsUtils.WEB_RESOURCE_UPLOADS_PATH;
-
 /**
  * SystemSettings DAO
  *
@@ -245,7 +242,10 @@ public class SystemSettingsDAO {
 	}
 
 	public static boolean getBooleanValue(String key) {
-		return getBooleanValue(key, false);
+		Boolean defaultValue = (Boolean) DEFAULT_VALUES.get(key);
+		if(defaultValue == null)
+			return getBooleanValue(key, false);
+		return getBooleanValue(key, defaultValue);
 	}
 
 	public static boolean getBooleanValue(String key, boolean defaultValue) {
@@ -255,6 +255,7 @@ public class SystemSettingsDAO {
 		return DAO.charToBool(value);
 	}
 
+	@Deprecated(since = "2.7.7.1")
 	public static boolean getBooleanValueOrDefault(String key) {
 		String value = getValue(key, null);
 		if (value == null)

--- a/src/org/scada_lts/mango/service/SystemSettingsService.java
+++ b/src/org/scada_lts/mango/service/SystemSettingsService.java
@@ -132,14 +132,14 @@ public class SystemSettingsService {
         JsonSettingsMisc json = new JsonSettingsMisc();
         json.setUiPerformance(SystemSettingsDAO.getIntValue(SystemSettingsDAO.UI_PERFORMANCE));
         json.setDataPointRuntimeValueSynchronized(SystemSettingsDAO.getValue(SystemSettingsDAO.DATAPOINT_RUNTIME_VALUE_SYNCHRONIZED));
-        json.setHideShortcutDisableFullScreen(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.VIEW_HIDE_SHORTCUT_DISABLE_FULL_SCREEN, false));
-        json.setEnableFullScreen(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.VIEW_FORCE_FULL_SCREEN_MODE, false));
-        json.setEventPendingLimit(SystemSettingsDAO.getIntValue(SystemSettingsDAO.EVENT_PENDING_LIMIT, 100));
-        json.setEventPendingCacheEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.EVENT_PENDING_CACHE_ENABLED, false));
-        json.setThreadsNameAdditionalLength(SystemSettingsDAO.getIntValue(SystemSettingsDAO.THREADS_NAME_ADDITIONAL_LENGTH, 255));
-        json.setWorkItemsReportingEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.WORK_ITEMS_REPORTING_ENABLED, true));
-        json.setWorkItemsReportingItemsPerSecondEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_ENABLED, true));
-        json.setWorkItemsReportingItemsPerSecondLimit(SystemSettingsDAO.getIntValue(SystemSettingsDAO.WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_LIMIT, 20000));
+        json.setHideShortcutDisableFullScreen(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.VIEW_HIDE_SHORTCUT_DISABLE_FULL_SCREEN));
+        json.setEnableFullScreen(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.VIEW_FORCE_FULL_SCREEN_MODE));
+        json.setEventPendingLimit(SystemSettingsDAO.getIntValue(SystemSettingsDAO.EVENT_PENDING_LIMIT));
+        json.setEventPendingCacheEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.EVENT_PENDING_CACHE_ENABLED));
+        json.setThreadsNameAdditionalLength(SystemSettingsDAO.getIntValue(SystemSettingsDAO.THREADS_NAME_ADDITIONAL_LENGTH));
+        json.setWorkItemsReportingEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.WORK_ITEMS_REPORTING_ENABLED));
+        json.setWorkItemsReportingItemsPerSecondEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_ENABLED));
+        json.setWorkItemsReportingItemsPerSecondLimit(SystemSettingsDAO.getIntValue(SystemSettingsDAO.WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_LIMIT));
         json.setWebResourceGraphicsPath(SystemSettingsDAO.getValue(SystemSettingsDAO.WEB_RESOURCE_GRAPHICS_PATH));
         json.setWebResourceUploadsPath(SystemSettingsDAO.getValue(SystemSettingsDAO.WEB_RESOURCE_UPLOADS_PATH));
         return json;
@@ -362,7 +362,7 @@ public class SystemSettingsService {
 
     public AggregateSettings getAggregateSettings() {
         AggregateSettings aggregateSettings = new AggregateSettings();
-        aggregateSettings.setEnabled(SystemSettingsDAO.getBooleanValueOrDefault(SystemSettingsDAO.AGGREGATION_ENABLED));
+        aggregateSettings.setEnabled(SystemSettingsDAO.getBooleanValue(SystemSettingsDAO.AGGREGATION_ENABLED));
         aggregateSettings.setValuesLimit(SystemSettingsDAO.getIntValue(SystemSettingsDAO.AGGREGATION_VALUES_LIMIT));
 
         try {

--- a/src/org/scada_lts/svg/SvgEnv.java
+++ b/src/org/scada_lts/svg/SvgEnv.java
@@ -9,18 +9,19 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public enum SvgEnvKeys {
+public enum SvgEnv {
     SVG_ONLY_XML_KEY("svg.validator.only-xml"),
     SVG_VALIDATOR_ENABLED_KEY("svg.validator.enabled"),
     SVG_SCHEMA_PATH_KEY("svg.validator.schemas"),
     SVG_IGNORE_TAGS_KEY("svg.validator.tags.ignore"),
-    SVG_IGNORE_MESSAGES_KEY("svg.validator.messages.ignore");
+    SVG_IGNORE_MESSAGES_KEY("svg.validator.messages.ignore"),
+    SVG_VALIDATOR_DISALLOW_DOCTYPE_DECL_ENABLED_KEY("svg.validator.disallow-doctype-decl.enabled");
 
-    private static final Log LOG = LogFactory.getLog(SvgEnvKeys.class);
+    private static final Log LOG = LogFactory.getLog(SvgEnv.class);
 
     private final String key;
 
-    SvgEnvKeys(String key) {
+    SvgEnv(String key) {
         this.key = key;
     }
 
@@ -43,6 +44,15 @@ public enum SvgEnvKeys {
         } catch (IOException e) {
             LOG.warn(e.getMessage());
             return true;
+        }
+    }
+
+    public static boolean isDisallowDoctypeDeclarationEnabled() {
+        try {
+            return ScadaConfig.getInstance().getBoolean(SVG_VALIDATOR_DISALLOW_DOCTYPE_DECL_ENABLED_KEY.getKey(), false);
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+            return false;
         }
     }
 
@@ -83,6 +93,6 @@ public enum SvgEnvKeys {
     }
 
     public static Map<String, String> getConfig() {
-        return Stream.of(SvgEnvKeys.values()).collect(Collectors.toMap(SvgEnvKeys::getKey, a -> get(a.getKey())));
+        return Stream.of(SvgEnv.values()).collect(Collectors.toMap(SvgEnv::getKey, a -> get(a.getKey())));
     }
 }

--- a/src/org/scada_lts/svg/SvgProcessingUtils.java
+++ b/src/org/scada_lts/svg/SvgProcessingUtils.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI;
-import static org.scada_lts.svg.SvgEnvKeys.*;
+import static org.scada_lts.svg.SvgEnv.*;
 import static org.scada_lts.utils.PathSecureUtils.toSecurePath;
 import static org.scada_lts.utils.UploadFileUtils.normalizeSeparator;
 import static org.scada_lts.utils.xml.XmlUtils.newValidator;
@@ -36,7 +36,7 @@ final class SvgProcessingUtils {
     private static final Log LOG = LogFactory.getLog(SvgProcessingUtils.class);
 
     public static boolean isValidatorEnabled() {
-        return SvgEnvKeys.isEnabled();
+        return isEnabled();
     }
 
     public static boolean isSvg(Document document) {

--- a/src/org/scada_lts/utils/StaticImagesUtils.java
+++ b/src/org/scada_lts/utils/StaticImagesUtils.java
@@ -24,8 +24,12 @@ public final class StaticImagesUtils {
 
     public static ResponseEntity<String> getAndSendImage(HttpServletRequest request, HttpServletResponse response) {
         File file = getSystemFileByRequest(request);
-        if(!Files.exists(file.toPath()) && Files.notExists(file.toPath()))
+        boolean exists = Files.exists(file.toPath());
+        boolean notExists = Files.notExists(file.toPath());
+        if(!exists && notExists)
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        if(exists == notExists)
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         if(!UploadFileUtils.isToUploads(file))
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         try {
@@ -60,6 +64,8 @@ public final class StaticImagesUtils {
         int bufferSize = 2048;
         byte[] data = new byte[bufferSize];
         int len;
+        String contentType = Files.probeContentType(file.toPath());
+        response.setContentType(contentType);
         try (InputStream inputStream = new FileInputStream(file);
              ServletOutputStream output = response.getOutputStream()) {
             while ((len = inputStream.read(data, 0, bufferSize)) != -1) {

--- a/src/org/scada_lts/utils/SystemSettingsUtils.java
+++ b/src/org/scada_lts/utils/SystemSettingsUtils.java
@@ -44,8 +44,8 @@ public final class SystemSettingsUtils {
     public static final String WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_ENABLED_KEY = "workitems.reporting.itemspersecond.enabled";
     public static final String WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_LIMIT_KEY = "workitems.reporting.itemspersecond.limit";
     public static final String THREADS_NAME_ADDITIONAL_LENGTH_KEY = "threads.name.additional.length";
-    public static final String WEB_RESOURCE_GRAPHICS_PATH = "webresource.graphics.path";
-    public static final String WEB_RESOURCE_UPLOADS_PATH = "webresource.uploads.path";
+    public static final String WEB_RESOURCE_GRAPHICS_PATH_KEY = "webresource.graphics.path";
+    public static final String WEB_RESOURCE_UPLOADS_PATH_KEY = "webresource.uploads.path";
 
     private static final org.apache.commons.logging.Log LOG = LogFactory.getLog(SystemSettingsUtils.class);
 
@@ -338,7 +338,7 @@ public final class SystemSettingsUtils {
 
     public static String getWebResourceUploadsPath() {
         try {
-            return ScadaConfig.getInstance().getConf().getProperty(WEB_RESOURCE_UPLOADS_PATH, "");
+            return ScadaConfig.getInstance().getConf().getProperty(WEB_RESOURCE_UPLOADS_PATH_KEY, "");
         } catch (Exception e) {
             LOG.error(e.getMessage());
             return "";
@@ -347,7 +347,7 @@ public final class SystemSettingsUtils {
 
     public static String getWebResourceGraphicsPath() {
         try {
-            return ScadaConfig.getInstance().getConf().getProperty(WEB_RESOURCE_GRAPHICS_PATH, "");
+            return ScadaConfig.getInstance().getConf().getProperty(WEB_RESOURCE_GRAPHICS_PATH_KEY, "");
         } catch (Exception e) {
             LOG.error(e.getMessage());
             return "";

--- a/src/org/scada_lts/utils/xml/XmlUtils.java
+++ b/src/org/scada_lts/utils/xml/XmlUtils.java
@@ -2,6 +2,7 @@ package org.scada_lts.utils.xml;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.scada_lts.svg.SvgEnv;
 import org.scada_lts.utils.security.SafeFile;
 import org.scada_lts.utils.security.SafeMultipartFile;
 import org.scada_lts.utils.security.SafeZipEntry;
@@ -26,7 +27,7 @@ public final class XmlUtils {
     private XmlUtils() {}
 
     public static Validator newRestrictionValidator(Schema schema) throws SAXNotSupportedException, SAXNotRecognizedException {
-        return newValidator(schema, a -> false, a -> false);
+        return newValidator(schema, a -> false, a -> false, true);
     }
 
     public static Validator newValidator(Schema schema, Predicate<String> isIgnoreErrorMsg) throws SAXNotSupportedException, SAXNotRecognizedException {
@@ -36,9 +37,16 @@ public final class XmlUtils {
     public static Validator newValidator(Schema schema,
                                          Predicate<String> isIgnoreErrorMsg,
                                          Predicate<String> isIgnoreWarnMsg) throws SAXNotSupportedException, SAXNotRecognizedException {
+        return newValidator(schema, isIgnoreErrorMsg, isIgnoreWarnMsg, SvgEnv.isDisallowDoctypeDeclarationEnabled());
+    }
+
+    public static Validator newValidator(Schema schema,
+                                         Predicate<String> isIgnoreErrorMsg,
+                                         Predicate<String> isIgnoreWarnMsg,
+                                         boolean disallowDoctypeDeclarationEnabled) throws SAXNotSupportedException, SAXNotRecognizedException {
         Validator validator = schema.newValidator();
         validator.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        validator.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        validator.setFeature("http://apache.org/xml/features/disallow-doctype-decl", disallowDoctypeDeclarationEnabled);
         validator.setFeature("http://xml.org/sax/features/external-general-entities", false);
         validator.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
         validator.setErrorHandler(new ErrorHandler() {
@@ -69,9 +77,13 @@ public final class XmlUtils {
     }
 
     public static DocumentBuilderFactory newDocumentBuilderFactory() throws ParserConfigurationException {
+        return newDocumentBuilderFactory(SvgEnv.isDisallowDoctypeDeclarationEnabled());
+    }
+
+    public static DocumentBuilderFactory newDocumentBuilderFactory(boolean disallowDoctypeDeclarationEnabled) throws ParserConfigurationException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", disallowDoctypeDeclarationEnabled);
         documentBuilderFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         documentBuilderFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
         documentBuilderFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);

--- a/src/org/scada_lts/web/mvc/api/json/JsonSettingsMisc.java
+++ b/src/org/scada_lts/web/mvc/api/json/JsonSettingsMisc.java
@@ -19,6 +19,7 @@ public class JsonSettingsMisc implements Serializable {
 
     public JsonSettingsMisc() {}
 
+    @Deprecated(since = "2.7.7.1")
     public JsonSettingsMisc(int uiPerformance, String dataPointRuntimeValueSynchronized, boolean enableFullScreen, boolean hideShortcutDisableFullScreen, int eventPendingLimit, boolean eventPendingCacheEnabled, String webResourceGraphicsPath, String webResourceUploadsPath) {
         this.uiPerformance = uiPerformance;
         this.dataPointRuntimeValueSynchronized = dataPointRuntimeValueSynchronized;

--- a/test/WEB-INF/classes/env.properties
+++ b/test/WEB-INF/classes/env.properties
@@ -64,7 +64,7 @@ abilit.START_UPDATE_UNSILENCED_ALARM_LEVEL=100000
 abilit.START_UPDATE_EVENT_DETECTORS=100000
 abilit.START_UPDATE_PENDING_EVENTS=100000
 abilit.MILLIS_SECONDS_PERIOD_UPDATE_UNSILENCED_ALARM_LEVEL=1000
-abilit.MILLIS_SECONDS_PERIOD_UPDATE_EVENT_DETECTORS=1000
+#abilit.MILLIS_SECONDS_PERIOD_UPDATE_EVENT_DETECTORS=1000
 abilit.MILLIS_SECONDS_PERIOD_UPDATE_PENDING_EVENTS=1000
 abilit.CRONE_UPDATE_CACHE_POINT_HIERARCHY=0 0/10 * * * ?
 
@@ -86,4 +86,64 @@ abilit.HTTP_RETRIVER_DO_NOT_ALLOW_ENABLE_REACTIVATION=false
 #security.hashAlgorithm=NONE
 #grove.url=http://mango.serotoninsoftware.com/servlet
 
-datapoint.runtime.value.synchronized=partial
+api.amcharts.aggregation.enabled=true
+api.amcharts.aggregation.valuesLimit=20000
+api.amcharts.aggregation.limitFactor=1.5
+
+user.cache.enabled=true
+usersprofile.cache.enabled=true
+permissions.cache.enabled=true
+shareuser.cache.enabled=true
+usercomment.cache.enabled=true
+view.cache.enabled=true
+
+alarmlevel.highest.cache.enabled=true
+alarmlevel.highest.cache.reset.enabled=true
+alarmlevel.highest.cache.reset.cron=0 0 1/3 ? * * *
+
+svg.validator.enabled=true
+svg.validator.only-xml=false
+svg.validator.schemas=svg/svg11-flat-20110816/svg11-flat-20110816.xsd;svg/svg10-flat-20010904/svg10-flat-20010904.xsd
+# Incompatible with SVG 1.0/1.1/1.1 Second Edition/1.1 Tiny/1.1 Basic - often found in files;
+# rdf:RDF - https://www.w3.org/TR/SVGTiny12/metadata.html
+svg.validator.tags.ignore=rdf:RDF;sodipodi:namedview;inkscape:perspective
+svg.validator.messages.ignore=must appear on element;Attribute 'blend' is not allowed to appear in element 'feBlend'.;sodipodi:;inkscape:;Attribute 'vector-effect' is not allowed to appear in element 'g'.
+systemsettings.http.response.headers={}
+
+datapoint.runtime.value.synchronized=NONE
+
+comm.serial.timeout.read=500
+comm.serial.timeout.write=500
+comm.serial.timeout.mode=0
+comm.serial.sleep=1000
+
+systemsettings.email.timeout=60000
+processing.workitems.limit=51
+processing.workitems.failed.limit=51
+processing.workitems.running.limit=51
+processing.workitems.running.repeat=51
+processing.workitems.history.process.limit=51
+processing.workitems.history.priority.high.limit=51
+processing.workitems.history.priority.medium.limit=51
+processing.workitems.history.priority.low.limit=51
+processing.workitems.history.longer.thanMs=1500
+processing.workitems.history.longer.limit=200
+
+scadalts.security.js.access.denied.method.regexes=getDeclaredField;getPassword;getClass;getRuntime;exec
+scadalts.security.js.access.denied.class.regexes=java.lang.Runtime;java.lang.Runtime.*;java.lang.reflect.*;java.lang.ref.*;java.lang.System.*;java.lang.System;java.lang.ClassLoader;java.lang.Compiler;java.lang.SecurityManager;java.lang.Thread;java.lang.ThreadGroup;java.lang.ThreadLocal
+scadalts.security.js.access.granted.method.regexes=^.*
+scadalts.security.js.access.granted.class.regexes=^.*
+
+view.forceFullScreen=false
+view.hideShortcutDisableFullScreen=false
+eventdetector.cache.enabled=true
+event.pending.limit=101
+event.pending.update.limit=5001
+threads.name.additional.length=5
+workitems.reporting.enabled=false
+workitems.reporting.itemspersecond.enabled=false
+workitems.reporting.itemspersecond.limit=20000
+
+webresource.uploads.path=static/uploads
+webresource.graphics.path=static/graphics
+svg.validator.disallow-doctype-decl.enabled=false

--- a/test/env.properties
+++ b/test/env.properties
@@ -22,6 +22,8 @@
 # ALTERE A LINHA db.password=admin (COLOQUE A SENHA DEFINIDA POR VOC\u00ca)
 # N\u00c3O REMOVA A LINHA db.url.public=jdbc:postgresql://localhost:5432/postgres
 
+#testowy!!!!
+
 #db.type=postgres
 #db.url=jdbc:postgresql://localhost:5432/scadabr
 #db.url.public=jdbc:postgresql://localhost:5432/postgres
@@ -141,3 +143,7 @@ threads.name.additional.length=5
 workitems.reporting.enabled=false
 workitems.reporting.itemspersecond.enabled=false
 workitems.reporting.itemspersecond.limit=20000
+
+webresource.uploads.path=static/uploads
+webresource.graphics.path=static/graphics
+svg.validator.disallow-doctype-decl.enabled=false

--- a/test/org/scada_lts/utils/xml/XmlConfigSecurityTest.java
+++ b/test/org/scada_lts/utils/xml/XmlConfigSecurityTest.java
@@ -49,7 +49,7 @@ public class XmlConfigSecurityTest {
     }
 
     @Test
-    public void when_getFeature_namespaces_then_false() throws ParserConfigurationException {
+    public void when_getFeature_namespaces_then_true() throws ParserConfigurationException {
         //when:
         boolean result = subject.getFeature("http://xml.org/sax/features/namespaces");
 
@@ -63,7 +63,7 @@ public class XmlConfigSecurityTest {
         boolean result = subject.getFeature("http://apache.org/xml/features/disallow-doctype-decl");
 
         //then:
-        assertEquals(true, result);
+        assertEquals(false, result);
     }
 
     @Test
@@ -85,7 +85,7 @@ public class XmlConfigSecurityTest {
     }
 
     @Test
-    public void when_getFeature_secure_processing_then_false() throws ParserConfigurationException {
+    public void when_getFeature_secure_processing_then_true() throws ParserConfigurationException {
         //when:
         boolean result = subject.getFeature("http://javax.xml.XMLConstants/feature/secure-processing");
 

--- a/test/org/scada_lts/utils/xml/XmlValidatorConfigSecurityTest.java
+++ b/test/org/scada_lts/utils/xml/XmlValidatorConfigSecurityTest.java
@@ -36,7 +36,7 @@ public class XmlValidatorConfigSecurityTest {
         boolean result = subject.getFeature("http://apache.org/xml/features/disallow-doctype-decl");
 
         //then:
-        assertEquals(true, result);
+        assertEquals(false, result);
     }
 
     @Test

--- a/webapp-resources/env.properties
+++ b/webapp-resources/env.properties
@@ -145,3 +145,4 @@ workitems.reporting.itemspersecond.limit=20000
 
 webresource.uploads.path=static/uploads
 webresource.graphics.path=static/graphics
+svg.validator.disallow-doctype-decl.enabled=false


### PR DESCRIPTION
- fixed visible svg for chrome browser; (added Content-Type image/svg+xml to header);
- Allowing doctype declaration in svg file - added properties 'svg.validator.disallow-doctype-decl.enabled' to env.properties;
- If the view is not in resolution mode, sets the default size for svg;
- Corrected tests: XmlConfigSecurityTest, XmlValidatorConfigSecurityTest - default value for disallow-doctype-decl is false;
- Refactor SystemSettingsService.getMiscSettings, SystemSettingsDAO.getBooleanValue, change enum name from SvgEnvKeys to SvgEnv, corrected name WEB_RESOURCE_GRAPHICS_PATH_KEY and WEB_RESOURCE_UPLOADS_PATH_KEY in SystemSettingsUtils;
- Deprecated constructor in JsonSettingsMisc is not used;