### PR TITLE
#2823 Fixed Consolidated chart not showing all data from report

### DIFF
--- a/src/com/serotonin/mango/vo/report/ImageChartUtils.java
+++ b/src/com/serotonin/mango/vo/report/ImageChartUtils.java
@@ -142,7 +142,7 @@ public class ImageChartUtils {
             int intervalIndex = 1;
             for (int i = 0; i < pointTimeSeriesCollection.getDiscreteSeriesCount(); i++) {
                 DiscreteTimeSeries dts = pointTimeSeriesCollection.getDiscreteTimeSeries(i);
-                TimeSeries ts = new TimeSeries(dts.getName(), null, null, Second.class);
+                TimeSeries ts = new TimeSeries(dts.getName(), null, null);
 
                 for (PointValueTime pvt : dts.getValueTimes())
                     ImageChartUtils.addSecond(ts, pvt.getTime(),

--- a/src/com/serotonin/mango/vo/report/ReportChartCreator.java
+++ b/src/com/serotonin/mango/vo/report/ReportChartCreator.java
@@ -460,6 +460,7 @@ public class ReportChartCreator {
         private TimeSeries numericTimeSeries;
         private DiscreteTimeSeries discreteTimeSeries;
         private AbstractDataQuantizer quantizer;
+        private HashMap<String, Integer> nameCount = new HashMap<>();
 
         public StreamHandler(long start, long end, int imageWidth, boolean createExportFile, ResourceBundle bundle) {
             pointStatistics = new ArrayList<PointStatistics>();
@@ -489,6 +490,8 @@ public class ReportChartCreator {
 
         public void startPoint(ReportPointInfo pointInfo) {
             donePoint();
+
+            changeNameDuplicates(pointInfo);
 
             point = new PointStatistics(pointInfo.getReportPointId(), inlinePrefix);
             point.setName(pointInfo.getExtendedNameForReport());
@@ -591,6 +594,17 @@ public class ReportChartCreator {
                 ImageChartUtils.addSecond(numericTimeSeries, time, MangoValue.numberValue(value));
             else if (discreteTimeSeries != null)
                 discreteTimeSeries.addValueTime(new PointValueTime(value, time));
+        }
+
+        public void changeNameDuplicates(ReportPointInfo pointInfo) {
+            String extendedName = pointInfo.getExtendedNameForReport();
+            if (nameCount.containsKey(extendedName)) {
+                int count = nameCount.get(extendedName);
+                nameCount.put(extendedName, count + 1);
+                pointInfo.setPointName(pointInfo.getPointName() + " (" + count + ")");
+            } else {
+                nameCount.put(extendedName, 1);
+            }
         }
     }
 }


### PR DESCRIPTION
- Added duplicate point name control so now if more than one point have the same name (1),(2),(...) is added to name, that prevents TimeSeriesCollection from making errors when recognizing TimeSeries (only parameter it was checking was name so now this error shouldn't happen)