### PR TITLE
#2871 Fixed NativeJavaObject for DataPoint Alphanumeric type - the pr…

### DIFF
--- a/src/com/serotonin/mango/MangoContextListener.java
+++ b/src/com/serotonin/mango/MangoContextListener.java
@@ -100,7 +100,9 @@ public class MangoContextListener implements ServletContextListener {
 
 	private void initialized(ServletContextEvent evt) {
 		log.info("Scada-LTS context starting at: " + Common.getStartupTime());
-		
+
+		scriptContextInitialize();
+
 		// Get a handle on the context.
 		ServletContext ctx = evt.getServletContext();
 
@@ -160,8 +162,6 @@ public class MangoContextListener implements ServletContextListener {
 		
 		reportsInitialize();
 		maintenanceInitialize();
-		
-		scriptContextInitialize();
 
 		// Notify the event manager of the startup.
 		SystemEventType.raiseEvent(new SystemEventType(


### PR DESCRIPTION
…oblem was caused by initializing the rhino context too late, after initializing the RuntimeManager, the solution is to initialize the script context at the beginning of the application initialization;