### PR TITLE
#2915 Fixed Changing register range for coil and input status in Modbus IP

### DIFF
--- a/WebContent/WEB-INF/jsp/dataSourceEdit/editModbusIp.jsp
+++ b/WebContent/WEB-INF/jsp/dataSourceEdit/editModbusIp.jsp
@@ -39,6 +39,7 @@
   
   function initImpl() {
 	  checkTransportType($get("transportType"));
+	  changeRange("test_")
   }
 
   function scanImpl() {


### PR DESCRIPTION
#2915 Fixed Changing register range for coil and input status in Modbus IP

- Added register range refresh when initializing modbus IP edit view which prevents user from choosing illegal modbus data type