### PR TITLE
#2799 Allow modbus tcp slave id to be zero

### DIFF
--- a/src/com/serotonin/mango/vo/dataSource/modbus/ModbusPointLocatorVO.java
+++ b/src/com/serotonin/mango/vo/dataSource/modbus/ModbusPointLocatorVO.java
@@ -291,8 +291,8 @@ public class ModbusPointLocatorVO extends AbstractPointLocatorVO implements
 		if (!MODBUS_DATA_TYPE_CODES.isValidId(modbusDataType))
 			response.addContextualMessage("modbusDataType",
 					"validate.invalidValue");
-		if (!StringUtils.isBetweenInc(slaveId, 1, 255) && !socketMonitor)
-			response.addContextualMessage("slaveId", "validate.1to255");
+		if (!StringUtils.isBetweenInc(slaveId, 0, 255) && !socketMonitor)
+			response.addContextualMessage("slaveId", "validate.0to255");
 
 		if (!slaveMonitor && !socketMonitor) {
 			int maxEndOffset = 65536 - DataType

--- a/webapp-resources/messages_de.properties
+++ b/webapp-resources/messages_de.properties
@@ -3369,3 +3369,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_en.properties
+++ b/webapp-resources/messages_en.properties
@@ -3372,3 +3372,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_es.properties
+++ b/webapp-resources/messages_es.properties
@@ -3412,3 +3412,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_fi.properties
+++ b/webapp-resources/messages_fi.properties
@@ -3497,3 +3497,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_fr.properties
+++ b/webapp-resources/messages_fr.properties
@@ -3366,3 +3366,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_lu.properties
+++ b/webapp-resources/messages_lu.properties
@@ -3385,3 +3385,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_nl.properties
+++ b/webapp-resources/messages_nl.properties
@@ -3487,3 +3487,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_pl.properties
+++ b/webapp-resources/messages_pl.properties
@@ -3509,3 +3509,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_pt.properties
+++ b/webapp-resources/messages_pt.properties
@@ -3524,3 +3524,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_ru.properties
+++ b/webapp-resources/messages_ru.properties
@@ -3520,3 +3520,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive

--- a/webapp-resources/messages_zh.properties
+++ b/webapp-resources/messages_zh.properties
@@ -3472,3 +3472,4 @@ systemsettings.reports.dataPointExtendedNameLengthLimit=Point name length limit 
 event.ds.recursiveError=Recursive Error
 event.meta.recursiveError=Recursive error in point "{0}": {1}
 validate.cyclicDependency=Cyclic dependency: {0}
+validate.0to255=Must be between 0 and 255 inclusive


### PR DESCRIPTION
Added option to set modbus data point slave id to range from 0 to 255 instead of range from 1 to 255