### PR TITLE
#3154 Adding the Data Source name to the deletion confirmation message

### DIFF
--- a/WebContent/WEB-INF/jsp/dataSourceList.jsp
+++ b/WebContent/WEB-INF/jsp/dataSourceList.jsp
@@ -62,8 +62,10 @@
             setDataPointStatusImg(enabled, imgNode);
     }
     
-    function deleteDataSource(dataSourceId) {
-        if (confirm("<spring:message code="dsList.dsDeleteConfirm"/>")) {
+    function deleteDataSource(dataSourceId, name, xid) {
+      var template = "<spring:message code="dsList.dsDeleteConfirmNamed"/>";
+      var msg = template.replace("{0}", name).replace("{1}", xid);
+        if (confirm(msg)) {
             startImageFader("deleteDataSourceImg"+ dataSourceId);
             DataSourceListDwr.deleteDataSource(dataSourceId, function(dataSourceId) {
                 stopImageFader("deleteDataSourceImg"+ dataSourceId);
@@ -152,8 +154,8 @@
                       <a href="data_source_edit.shtm?dsid=${listParent.parent.id}"><tag:img png="icon_ds_edit"
                               title="common.edit"/></a>
                       <tag:img png="arrow_out" title="dsList.show" onclick="togglePanelVisibility2(this, 'points${listParent.parent.id}', '${hideText}', '${showText}');"/>
-                      <tag:img png="icon_ds_delete" title="common.delete" id="deleteDataSourceImg${listParent.parent.id}" 
-                              onclick="deleteDataSource(${listParent.parent.id})"/>
+                      <tag:img png="icon_ds_delete" title="common.delete" id="deleteDataSourceImg${listParent.parent.id}"
+                               onclick="deleteDataSource(${listParent.parent.id}, '${fn:escapeXml(listParent.parent.name)}', '${fn:escapeXml(listParent.parent.xid)}')"/>
                       <tag:img png="icon_ds_add" title="common.copy" id="copyDataSourceImg${listParent.parent.id}" 
                               onclick="copyDataSource(${listParent.parent.id})"/>
                     </td>

--- a/WebContent/WEB-INF/jsp/dataSourceList.jsp
+++ b/WebContent/WEB-INF/jsp/dataSourceList.jsp
@@ -62,8 +62,10 @@
             setDataPointStatusImg(enabled, imgNode);
     }
     
-    function deleteDataSource(dataSourceId, name, xid) {
-      var template = "<spring:message code="dsList.dsDeleteConfirmNamed"/>";
+    function deleteDataSource(el, dataSourceId) {
+      var name = el.getAttribute("data-name") || "";
+      var xid  = el.getAttribute("data-xid")  || "";
+      var template = "<spring:message code='dsList.dsDeleteConfirmNamed'/>";
       var msg = template.replace("{0}", name).replace("{1}", xid);
         if (confirm(msg)) {
             startImageFader("deleteDataSourceImg"+ dataSourceId);
@@ -154,8 +156,12 @@
                       <a href="data_source_edit.shtm?dsid=${listParent.parent.id}"><tag:img png="icon_ds_edit"
                               title="common.edit"/></a>
                       <tag:img png="arrow_out" title="dsList.show" onclick="togglePanelVisibility2(this, 'points${listParent.parent.id}', '${hideText}', '${showText}');"/>
-                      <tag:img png="icon_ds_delete" title="common.delete" id="deleteDataSourceImg${listParent.parent.id}"
-                               onclick="deleteDataSource(${listParent.parent.id}, '${fn:escapeXml(listParent.parent.name)}', '${fn:escapeXml(listParent.parent.xid)}')"/>
+                      <tag:img png="icon_ds_delete"
+                               title="common.delete"
+                               id="deleteDataSourceImg${listParent.parent.id}"
+                               dataName="${listParent.parent.name}"
+                               dataXid="${listParent.parent.xid}"
+                               onclick="deleteDataSource(this, ${listParent.parent.id})"/>
                       <tag:img png="icon_ds_add" title="common.copy" id="copyDataSourceImg${listParent.parent.id}" 
                               onclick="copyDataSource(${listParent.parent.id})"/>
                     </td>

--- a/WebContent/WEB-INF/tags/img.tag
+++ b/WebContent/WEB-INF/tags/img.tag
@@ -25,6 +25,8 @@
 --%><%@attribute name="onmouseover"%><%--
 --%><%@attribute name="onmouseout"%><%--
 --%><%@attribute name="style"%><%--
+--%><%@attribute name="dataName" rtexprvalue="true"%><%--
+--%><%@attribute name="dataXid"  rtexprvalue="true"%><%--
 --%><img class="ptr" <c:if test="${!empty id}"> id="${id}"</c:if><%--
 --%><c:if test="${!empty src}"> src="${src}"</c:if><%--
 --%><c:if test="${!empty png && empty src}"> src="images/${png}.png"</c:if><%--
@@ -33,4 +35,6 @@
 --%><c:if test="${!empty onmouseover}"> onmouseover="${onmouseover}"</c:if><%--
 --%><c:if test="${!empty onmouseout}"> onmouseout="${onmouseout}"</c:if><%--
 --%><c:if test="${!empty style}"> style="${style}"</c:if><%--
+--%><c:if test="${!empty dataName}"> data-name="<c:out value='${dataName}'/>"</c:if><%--
+--%><c:if test="${!empty dataXid}">  data-xid="<c:out value='${dataXid}'/>"</c:if><%--
 --%> border="0"/>

--- a/webapp-resources/messages_de.properties
+++ b/webapp-resources/messages_de.properties
@@ -3455,3 +3455,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Sind Sie sicher, dass Sie die Datenquelle {0} (XID: {1}) löschen möchten?

--- a/webapp-resources/messages_en.properties
+++ b/webapp-resources/messages_en.properties
@@ -3458,3 +3458,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Are you sure you wish to delete data source {0} (XID: {1})?

--- a/webapp-resources/messages_es.properties
+++ b/webapp-resources/messages_es.properties
@@ -3498,3 +3498,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=¿Está seguro de que desea eliminar la fuente de datos {0} (XID: {1})?

--- a/webapp-resources/messages_fi.properties
+++ b/webapp-resources/messages_fi.properties
@@ -3583,3 +3583,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Haluatko varmasti poistaa tietolähteen {0} (XID: {1})?

--- a/webapp-resources/messages_fr.properties
+++ b/webapp-resources/messages_fr.properties
@@ -3452,3 +3452,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Êtes-vous sûr de vouloir supprimer la source de données {0} (XID : {1}) ?

--- a/webapp-resources/messages_lu.properties
+++ b/webapp-resources/messages_lu.properties
@@ -3471,3 +3471,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Sidd Dir sécher datt Dir déi Datequell {0} (XID: {1}) läschen wëllt?

--- a/webapp-resources/messages_nl.properties
+++ b/webapp-resources/messages_nl.properties
@@ -3573,3 +3573,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Weet u zeker dat u de gegevensbron {0} (XID: {1}) wilt verwijderen?

--- a/webapp-resources/messages_pl.properties
+++ b/webapp-resources/messages_pl.properties
@@ -3595,3 +3595,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Czy na pewno chcesz usun?? ?ród?o danych {0} (XID: {1})?

--- a/webapp-resources/messages_pt.properties
+++ b/webapp-resources/messages_pt.properties
@@ -3610,3 +3610,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Tem certeza de que deseja excluir a fonte de dados {0} (XID: {1})?

--- a/webapp-resources/messages_ru.properties
+++ b/webapp-resources/messages_ru.properties
@@ -3606,3 +3606,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Are you sure you wish to delete data source {0} (XID: {1})?

--- a/webapp-resources/messages_zh.properties
+++ b/webapp-resources/messages_zh.properties
@@ -3558,3 +3558,4 @@ systemSettings.amChartsSaved=AmCharts settings have been saved
 systemSettings.scadaConfTitle=Scada-LTS environment settings
 systemSettings.scadaConfCheck=Check configuration
 validate.unsupportedDataType=Data type {0} is not supported
+dsList.dsDeleteConfirmNamed=Are you sure you wish to delete data source {0} (XID: {1})?


### PR DESCRIPTION
Now pop up window with confirmation looks like this:

<img width="875" height="309" alt="image" src="https://github.com/user-attachments/assets/15c6356d-8b90-4c42-b5a0-e7a32abe04e3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Data source deletion confirmations now display the specific data source name and unique identifier. This provides users with clearer context before confirming deletion and helps prevent accidental removal of unintended resources. Improved across all supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->