### PR TITLE
#3081 Fixed tables layouts in Publisher edit view

### DIFF
--- a/WebContent/WEB-INF/jsp/publisherEdit/editPersistent.jsp
+++ b/WebContent/WEB-INF/jsp/publisherEdit/editPersistent.jsp
@@ -192,7 +192,7 @@
   </tr>
 </table>
 
-<table cellpadding="0" cellspacing="0"><tr><td>
+<table cellpadding="0" cellspacing="0" style="width:100%;"><tr><td style="width:100%;">
   <div class="borderDiv">
     <table width="100%">
       <tr>
@@ -211,7 +211,7 @@
         <td><spring:message code="publisherEdit.point.type"/></td>
         <td></td>
       </tr>
-      <tbody id="selectedPointsEmpty" style="display:none;"><tr><td colspan="5"><spring:message code="publisherEdit.noPoints"/></td></tr></tbody>
+      <tbody id="selectedPointsEmpty" style="display:none;"><tr><td colspan="4"><spring:message code="publisherEdit.noPoints"/></td></tr></tbody>
       <tbody id="selectedPoints"></tbody>
     </table>
     <div id="pointsMsg" class="formError" style="display:none;"></div>


### PR DESCRIPTION
before:

<img width="656" height="749" alt="image" src="https://github.com/user-attachments/assets/c672713d-3599-422e-a44e-bd42d5e4ca16" />


after:

<img width="656" height="749" alt="image" src="https://github.com/user-attachments/assets/f19e5e3e-5955-47be-9df9-2f0cce1a208e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Made minor layout adjustments to improve visual presentation and spacing of UI elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->