### PR TITLE
#3233 Fixed change incorrect GET endpoints to POST

### DIFF
--- a/WebContent/WEB-INF/jsp/systemSettings.jsp
+++ b/WebContent/WEB-INF/jsp/systemSettings.jsp
@@ -497,7 +497,7 @@
         }
 
         jQuery.ajax({
-            type: 'GET',
+            type: 'POST',
             dataType: 'text',
             url:myLocation+"api/resources/imagesRefresh",
             success: function(msg){

--- a/WebContent/WEB-INF/spring-security.xml
+++ b/WebContent/WEB-INF/spring-security.xml
@@ -364,9 +364,9 @@
         <intercept-url pattern="/api/reports/search" access="hasAnyRole('ROLE_ADMIN', 'ROLE_USER')" method="POST" />
         <intercept-url pattern="/api/reports/sendTestEmails" access="hasAnyRole('ROLE_ADMIN', 'ROLE_USER')" method="POST" />
         <intercept-url pattern="/api/reports/instances" access="hasAnyRole('ROLE_ADMIN', 'ROLE_USER')" method="GET" />
-        <intercept-url pattern="/api/reports/instances/{id}/preventPurge/{preventPurge}" access="@guard.hasReportInstanceSetPermission(request,#id)" method="GET" />
+        <intercept-url pattern="/api/reports/instances/{id}/preventPurge/{preventPurge}" access="@guard.hasReportInstanceSetPermission(request,#id)" method="PUT" />
         <intercept-url pattern="/api/reports/instances/{id}" access="@guard.hasReportInstanceOwnerPermission(request,#id)" method="DELETE" />
-        <intercept-url pattern="/api/reports/run/{id}" access="@guard.hasReportSetPermission(request,#id,false)" method="GET" />
+        <intercept-url pattern="/api/reports/run/{id}" access="@guard.hasReportSetPermission(request,#id,false)" method="POST" />
         <intercept-url pattern="/api/reports/{id}" access="@guard.hasReportOwnerPermission(request,#id,false)" method="DELETE" />
 
         <!-- User PUT/GET -->

--- a/WebContent/WEB-INF/spring-security.xml
+++ b/WebContent/WEB-INF/spring-security.xml
@@ -341,6 +341,7 @@
         <!-- REST API User -->
         <!-- Auth -->
         <intercept-url pattern="/api/auth/**" access="permitAll" />
+        <intercept-url pattern="/api/v2/auth/**" access="permitAll" />
 
         <!-- WatchList POST/PUT/GET -->
         <intercept-url pattern="/api/watch-lists" access="hasAnyRole('ROLE_ADMIN', 'ROLE_USER')" method="POST" />

--- a/WebContent/resources/vue-mixins/shared/mixins-export-import.js
+++ b/WebContent/resources/vue-mixins/shared/mixins-export-import.js
@@ -11,7 +11,11 @@ var ExportImportHierarchiPoints = {
             try {
                 axios({
                     method: 'post',
-                    url: 'http://localhost:8080/ScadaBR/api/auth/admin/admin',
+                    url: 'http://localhost:8080/ScadaBR/api/auth',
+                    data: {
+                        username: 'admin',
+                        password: 'admin',
+                    },
                 }).then(function (response) {
                     alert(response.data);
                     alert(response.status);

--- a/WebContent/resources/vue-mixins/shared/mixins-export-import.js
+++ b/WebContent/resources/vue-mixins/shared/mixins-export-import.js
@@ -11,7 +11,7 @@ var ExportImportHierarchiPoints = {
             try {
                 axios({
                     method: 'post',
-                    url: 'http://localhost:8080/ScadaBR/api/auth',
+                    url: 'http://localhost:8080/ScadaBR/api/v2/auth',
                     data: {
                         username: 'admin',
                         password: 'admin',

--- a/doc/RESTAPI/ScadaLTS_API_OAS3.yaml
+++ b/doc/RESTAPI/ScadaLTS_API_OAS3.yaml
@@ -14,30 +14,41 @@ info:
   license:
     name: 'GPL-2.0'
 paths:
-  /auth:
+  /auth/{username}/{password}:
     post:
       tags:
         - AuthenticationAPI
       summary: 'Authenticate to the Scada-LTS'
       description: 'Login user to the ScadaLTS'
       operationId: 'loginUser'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AuthenticationRequest'
+      parameters:
+        - name: username
+          in: 'path'
+          required: true
+          schema:
+            type: 'string'
+        - name: 'password'
+          in: 'path'
+          required: true
+          schema:
+            type: 'string'
       responses:
         '200':
           description: 'Logged successful'
           headers: {}
-  /auth/logout:
+  /auth/logout/{username}:
     post:
       tags:
         - AuthenticationAPI
       summary: 'Logout from Scada-LTS'
       description: 'Logout user from Scada-LTS'
       operationId: 'logoutUser'
+      parameters:
+        - name: 'username'
+          in: 'path'
+          required: true
+          schema:
+            type: 'string'
       responses:
         '200':
           description: 'Logged out succesful'
@@ -769,30 +780,6 @@ paths:
       tags:
         - PointValueAPI
       deprecated: true
-      parameters:
-        - name: 'xid'
-          in: 'path'
-          required: true
-          schema:
-            type: string
-        - name: 'type'
-          description: 'Type 0 -> unknown, 1 -> binary, 2 -> Multistate, 3 -> Double, 4 -> String'
-          in: 'path'
-          required: true
-          schema:
-            type: string
-        - name: 'value'
-          description: 'For binary data acceptable only 0 or 1 value'
-          in: 'path'
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: ''
-    put:
-      tags:
-        - PointValueAPI
       parameters:
         - name: 'xid'
           in: 'path'
@@ -1803,7 +1790,7 @@ paths:
       responses:
         '200':
           description: ''
-  /view_hierarchy/getFirsViewId:
+  /view_hierarchy/getFirstViewId:
     get:
       tags:
         - ViewHierarchyAPI
@@ -2511,18 +2498,43 @@ paths:
         '200':
           description: ''
 
+  /v2/auth:
+    post:
+      tags:
+        - AuthenticationAPI
+      summary: 'Authenticate to the Scada-LTS'
+      description: 'Login user to the ScadaLTS'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - username
+                - password
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: 'Logged successful'
+          headers: {}
+  /v2/auth/logout:
+    post:
+      tags:
+        - AuthenticationAPI
+      summary: 'Logout from Scada-LTS'
+      description: 'Logout user from Scada-LTS'
+      responses:
+        '200':
+          description: 'Logged out succesful'
+          headers: {}
+
 components:
   schemas:
-    AuthenticationRequest:
-      type: object
-      required:
-        - username
-        - password
-      properties:
-        username:
-          type: string
-        password:
-          type: string
     JsonDataPoint:
       type: object
       properties:

--- a/doc/RESTAPI/ScadaLTS_API_OAS3.yaml
+++ b/doc/RESTAPI/ScadaLTS_API_OAS3.yaml
@@ -14,41 +14,30 @@ info:
   license:
     name: 'GPL-2.0'
 paths:
-  /auth/{username}/{password}:
-    get:
+  /auth:
+    post:
       tags:
         - AuthenticationAPI
       summary: 'Authenticate to the Scada-LTS'
       description: 'Login user to the ScadaLTS'
       operationId: 'loginUser'
-      parameters:
-        - name: username
-          in: 'path'
-          required: true
-          schema:
-            type: 'string'
-        - name: 'password'
-          in: 'path'
-          required: true
-          schema:
-            type: 'string'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthenticationRequest'
       responses:
         '200':
           description: 'Logged successful'
           headers: {}
-  /auth/logout/{username}:
-    get:
+  /auth/logout:
+    post:
       tags:
         - AuthenticationAPI
       summary: 'Logout from Scada-LTS'
       description: 'Logout user from Scada-LTS'
       operationId: 'logoutUser'
-      parameters:
-        - name: 'username'
-          in: 'path'
-          required: true
-          schema:
-            type: 'string'
       responses:
         '200':
           description: 'Logged out succesful'
@@ -263,6 +252,56 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/ScadaObjectIdentifier'
+  /datasource/toggle:
+    post:
+      tags:
+        - DataSourceAPI
+      parameters:
+        - name: 'id'
+          description: 'DataSource ID'
+          in: 'query'
+          required: false
+          schema:
+            type: number
+        - name: 'xid'
+          description: 'DataSource Export ID'
+          in: 'query'
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+  /datasource/datapoints/enable:
+    put:
+      tags:
+        - DataSourceAPI
+      parameters:
+        - name: 'id'
+          description: 'DataSource ID'
+          in: 'query'
+          required: false
+          schema:
+            type: number
+        - name: 'xid'
+          description: 'DataSource Export ID'
+          in: 'query'
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/JsonDataPoint'
   /userProfiles/:
     get:
       tags:
@@ -751,6 +790,30 @@ paths:
       responses:
         '200':
           description: ''
+    put:
+      tags:
+        - PointValueAPI
+      parameters:
+        - name: 'xid'
+          in: 'path'
+          required: true
+          schema:
+            type: string
+        - name: 'type'
+          description: 'Type 0 -> unknown, 1 -> binary, 2 -> Multistate, 3 -> Double, 4 -> String'
+          in: 'path'
+          required: true
+          schema:
+            type: string
+        - name: 'value'
+          description: 'For binary data acceptable only 0 or 1 value'
+          in: 'path'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: ''
   /point_value/setValue/{xid}/{type}/:
     post:
       tags:
@@ -882,7 +945,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/PointValuesJSON'
   /point_value/updateMetaDataPointByScript/{xid}:
-    get:
+    put:
       tags:
         - PointValueAPI
       parameters:
@@ -895,7 +958,7 @@ paths:
         '200':
           description: ''
   /point_value/updateMetaDataPointsByScript/{xid}:
-    get:
+    put:
       tags:
         - PointValueAPI
       parameters:
@@ -908,9 +971,40 @@ paths:
         '200':
           description: ''
   /point_value/updateAllMetaDataPointsByScript:
-    get:
+    put:
       tags:
         - PointValueAPI
+      responses:
+        '200':
+          description: ''
+  /reports/run/{id}:
+    post:
+      tags:
+        - ReportsAPI
+      parameters:
+        - name: 'id'
+          in: 'path'
+          required: true
+          schema:
+            type: number
+      responses:
+        '200':
+          description: ''
+  /reports/instances/{id}/preventPurge/{preventPurge}:
+    put:
+      tags:
+        - ReportsAPI
+      parameters:
+        - name: 'id'
+          in: 'path'
+          required: true
+          schema:
+            type: number
+        - name: 'preventPurge'
+          in: 'path'
+          required: true
+          schema:
+            type: boolean
       responses:
         '200':
           description: ''
@@ -1559,7 +1653,7 @@ paths:
         '200':
           description: ''
   /resources/imagesRefresh:
-    get:
+    post:
       tags:
         - ResourcesAPI
       responses:
@@ -1590,7 +1684,7 @@ paths:
                       items:
                         type: object
   /view_hierarchy/createFolder/{name}/{parentId}:
-    get:
+    post:
       tags:
         - ViewHierarchyAPI
       parameters:
@@ -2217,7 +2311,21 @@ paths:
                         count:
                           type: number
   /systemSettings/purgeData:
-    get:
+    post:
+      tags:
+        - SystemSettingsAPI
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /systemSettings/purgeNow:
+    post:
       tags:
         - SystemSettingsAPI
       responses:
@@ -2405,6 +2513,16 @@ paths:
 
 components:
   schemas:
+    AuthenticationRequest:
+      type: object
+      required:
+        - username
+        - password
+      properties:
+        username:
+          type: string
+        password:
+          type: string
     JsonDataPoint:
       type: object
       properties:

--- a/scadalts-ui/README.md
+++ b/scadalts-ui/README.md
@@ -24,7 +24,7 @@ Example usage of images was presented in `src/views/LoginPage/index.vue`
 
 ## Using the developmnet server
 When you start a development server to instant application building you have to log into the Scada-LTS. Dev server uses `"http-proxy-middleware-secure-cookies"` dependency to handle the connection within frontend and core application. When your server is ready you have to open your browser on the `http://localhost:3000/#/` and you should be redirected to login page. There you have to open the DevTools (F11 in Chrome) and open "Network" tab to monitor the HTTP requestes. Try to log into the application using the default password.
-When you receive the `xhr response` with RequestURL `*/api/auth/...` from server open that request details and find the **Response Headers** section. Then find a "set-cookie" header and copy that value. Then paste that cookie inside your DevServer because you were propably prompted to input a auth cookie there. If everything is ok you should see the  
+When you receive the `xhr response` with RequestURL `*/api/auth` from server open that request details and find the **Response Headers** section. Then find a "set-cookie" header and copy that value. Then paste that cookie inside your DevServer because you were propably prompted to input a auth cookie there. If everything is ok you should see the  
 `"Successfully saved your cookie. Please refresh."` message from the WebServer. Then you can easily develop the frontend application with on-fly updates and access to backend data. 
 
 If you have an issue with that try to logout from the core ScadaLTS application (that which is hosted on port 8080) and make sure cookies has been deleted there. In Chrome dev-tools open the "Appication" tab and click "Clear all cookies" button.

--- a/scadalts-ui/README.md
+++ b/scadalts-ui/README.md
@@ -24,7 +24,7 @@ Example usage of images was presented in `src/views/LoginPage/index.vue`
 
 ## Using the developmnet server
 When you start a development server to instant application building you have to log into the Scada-LTS. Dev server uses `"http-proxy-middleware-secure-cookies"` dependency to handle the connection within frontend and core application. When your server is ready you have to open your browser on the `http://localhost:3000/#/` and you should be redirected to login page. There you have to open the DevTools (F11 in Chrome) and open "Network" tab to monitor the HTTP requestes. Try to log into the application using the default password.
-When you receive the `xhr response` with RequestURL `*/api/auth` from server open that request details and find the **Response Headers** section. Then find a "set-cookie" header and copy that value. Then paste that cookie inside your DevServer because you were propably prompted to input a auth cookie there. If everything is ok you should see the  
+When you receive the `xhr response` with RequestURL `*/api/v2/auth` from server open that request details and find the **Response Headers** section. Then find a "set-cookie" header and copy that value. Then paste that cookie inside your DevServer because you were propably prompted to input a auth cookie there. If everything is ok you should see the  
 `"Successfully saved your cookie. Please refresh."` message from the WebServer. Then you can easily develop the frontend application with on-fly updates and access to backend data. 
 
 If you have an issue with that try to logout from the core ScadaLTS application (that which is hosted on port 8080) and make sure cookies has been deleted there. In Chrome dev-tools open the "Appication" tab and click "Clear all cookies" button.

--- a/scadalts-ui/cypress/integration/ScadaLTS_Views/modern_charts.cy.js
+++ b/scadalts-ui/cypress/integration/ScadaLTS_Views/modern_charts.cy.js
@@ -10,7 +10,7 @@ context('Verify Modern Watch List Page and Modern Charts', () => {
 
 	describe('Chart with 1 datapoint', function () {
 		it('Create chart', function () {
-			cy.request('/api/auth/admin/admin');
+			cy.request('POST', '/api/auth', { username: 'admin', password: 'admin' });
 			cy.get('#watchListSelect').select('Test_WL_1');
 			cy.get('i[class="glyphicon glyphicon-refresh"]').click();
 			cy.get('.hello').find('svg');

--- a/scadalts-ui/cypress/integration/ScadaLTS_Views/modern_charts.cy.js
+++ b/scadalts-ui/cypress/integration/ScadaLTS_Views/modern_charts.cy.js
@@ -10,7 +10,7 @@ context('Verify Modern Watch List Page and Modern Charts', () => {
 
 	describe('Chart with 1 datapoint', function () {
 		it('Create chart', function () {
-			cy.request('POST', '/api/auth', { username: 'admin', password: 'admin' });
+			cy.request('POST', '/api/v2/auth', { username: 'admin', password: 'admin' });
 			cy.get('#watchListSelect').select('Test_WL_1');
 			cy.get('i[class="glyphicon glyphicon-refresh"]').click();
 			cy.get('.hello').find('svg');

--- a/scadalts-ui/cypress/support/commands.js
+++ b/scadalts-ui/cypress/support/commands.js
@@ -52,7 +52,7 @@ Cypress.Commands.add('restLogin', (username = 'admin', password = 'admin') => {
 	cy.request({
 		log: false,
 		method: 'POST',
-		url: '/api/auth',
+		url: '/api/v2/auth',
 		body: {
 			username,
 			password,

--- a/scadalts-ui/cypress/support/commands.js
+++ b/scadalts-ui/cypress/support/commands.js
@@ -51,7 +51,12 @@ Cypress.Commands.add('restLogin', (username = 'admin', password = 'admin') => {
 	log.snapshot('before');
 	cy.request({
 		log: false,
-		url: `/api/auth/${username}/${password}`,
+		method: 'POST',
+		url: '/api/auth',
+		body: {
+			username,
+			password,
+		},
 	})
 		.its('body', { log: false })
 		.should('include', 'true');

--- a/scadalts-ui/src/store/dataSource/index.js
+++ b/scadalts-ui/src/store/dataSource/index.js
@@ -340,7 +340,10 @@ const ds = {
 
 		enableAllDataPoints({commit, dispatch}, dataSourceId) {
 			return new Promise((resolve, reject) => {
-				dispatch('requestGet', `/datasource/datapoints/enable?id=${dataSourceId}`)
+				dispatch('requestPut', {
+					url: `/datasource/datapoints/enable?id=${dataSourceId}`,
+					data: null,
+				})
 				.then((resp) => {
 					commit('ENABLE_ALL_DATA_POINTS_IN_DS', dataSourceId);
 					resolve();
@@ -353,7 +356,10 @@ const ds = {
 
 		toggleDataSource({commit, dispatch}, dataSourceId) {
 			return new Promise((resolve, reject) => {
-				dispatch('requestGet', `/datasource/toggle?id=${dataSourceId}`)
+				dispatch('requestPost', {
+					url: `/datasource/toggle?id=${dataSourceId}`,
+					data: null,
+				})
 				.then(() => {
 					commit('TOGGLE_DATA_SOURCE', dataSourceId);
 					resolve();

--- a/scadalts-ui/src/store/reports/index.js
+++ b/scadalts-ui/src/store/reports/index.js
@@ -50,7 +50,10 @@ const storeReports = {
 			.catch(() => { dispatch('showErrorNotification', 'Reports not loaded')});
 		},
 		setPreventPurge({ commit, dispatch }, payload) {
-			dispatch('requestGet', `/reports/instances/${payload.id}/preventPurge/${payload.preventPurge}`)
+			dispatch('requestPut', {
+				url: `/reports/instances/${payload.id}/preventPurge/${payload.preventPurge}`,
+				data: null,
+			})
 				.then((r) => { commit(TOGGLE_PURGE, r)})
 				.catch(() => { dispatch('showErrorNotification', 'Failed to save this property')});
 		},
@@ -67,7 +70,7 @@ const storeReports = {
 		},
 
 		runReport({ dispatch }, id) {
-			return dispatch('requestGet', `/reports/run/${id}`);
+			return dispatch('requestPost', { url: `/reports/run/${id}`, data: null });
 		},
 		fetchReports({ dispatch }, payload) {
 			return dispatch('requestPost', {

--- a/scadalts-ui/src/store/systemSettings/index.js
+++ b/scadalts-ui/src/store/systemSettings/index.js
@@ -286,7 +286,7 @@ const storeSystemSettings = {
 		purgeData(context) {
 			return new Promise((resolve, reject) => {
 				axios
-					.get(`${context.state.systemSettingsApiUrl}/purgeData`, {
+					.post(`${context.state.systemSettingsApiUrl}/purgeData`, null, {
 						timeout: 5000,
 						useCredentials: true,
 						credentials: 'same-origin',
@@ -305,7 +305,7 @@ const storeSystemSettings = {
 		},
 
 		purgeNow({dispatch}) {
-			return dispatch('requestGet', '/systemSettings/purgeNow');
+			return dispatch('requestPost', { url: '/systemSettings/purgeNow', data: null });
 		},
 
 		configurationEqual(ctx, objects) {

--- a/src/org/scada_lts/web/mvc/api/AuthenticationAPI.java
+++ b/src/org/scada_lts/web/mvc/api/AuthenticationAPI.java
@@ -40,11 +40,38 @@ public class AuthenticationAPI {
 		this.userService = userService;
 		this.authenticationManager = authenticationManager;
 	}
-	
-	@RequestMapping(value = "/api/auth/{username}/{password}", method = RequestMethod.POST)
-	public ResponseEntity<String> setAuthentication(@PathVariable("username") String username, @PathVariable("password") String password,
+
+	public static class AuthenticationRequest {
+		private String username;
+		private String password;
+
+		public String getUsername() {
+			return username;
+		}
+
+		public void setUsername(String username) {
+			this.username = username;
+		}
+
+		public String getPassword() {
+			return password;
+		}
+
+		public void setPassword(String password) {
+			this.password = password;
+		}
+	}
+
+	@PostMapping(value = "/api/auth")
+	public ResponseEntity<String> setAuthentication(@RequestBody(required = false) AuthenticationRequest authRequest,
 													HttpServletRequest request, HttpServletResponse response) {
-		LOG.info("/api/auth/{username}/{password} username:" + username);
+		if (authRequest == null || authRequest.getUsername() == null || authRequest.getPassword() == null) {
+			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+		}
+
+		String username = authRequest.getUsername();
+		String password = authRequest.getPassword();
+		LOG.info("/api/auth username:" + username);
 		Authentication authentication = authenticate(username, password, request, response, authenticationManager, userService);
 		return new ResponseEntity<>(String.valueOf(authentication.isAuthenticated()), HttpStatus.OK);
 	}
@@ -71,10 +98,10 @@ public class AuthenticationAPI {
 		return new ResponseEntity<>(String.valueOf(ok),HttpStatus.OK);
 	}
 	
-	@RequestMapping(value = "/api/auth/logout/{username}", method = RequestMethod.POST)
-	public ResponseEntity<String> setLogout(@PathVariable("username") String username, HttpServletRequest request) {
-		LOG.info("/api/auth/logout/{username} username:" + username);
-		User user = userService.getUser(username);
+	@PostMapping(value = "/api/auth/logout")
+	public ResponseEntity<String> setLogout(HttpServletRequest request) {
+		LOG.info("/api/auth/logout");
+		User user = Common.getUser(request);
 
 		if (user != null) {
 			logout(request);

--- a/src/org/scada_lts/web/mvc/api/AuthenticationAPI.java
+++ b/src/org/scada_lts/web/mvc/api/AuthenticationAPI.java
@@ -62,16 +62,24 @@ public class AuthenticationAPI {
 		}
 	}
 
-	@PostMapping(value = "/api/auth")
-	public ResponseEntity<String> setAuthentication(@RequestBody(required = false) AuthenticationRequest authRequest,
+	@RequestMapping(value = "/api/auth/{username}/{password}", method = RequestMethod.POST)
+	public ResponseEntity<String> setAuthentication(@PathVariable("username") String username, @PathVariable("password") String password,
 													HttpServletRequest request, HttpServletResponse response) {
+		LOG.info("/api/auth/{username}/{password} username:" + username);
+		Authentication authentication = authenticate(username, password, request, response, authenticationManager, userService);
+		return new ResponseEntity<>(String.valueOf(authentication.isAuthenticated()), HttpStatus.OK);
+	}
+
+	@PostMapping(value = "/api/v2/auth")
+	public ResponseEntity<String> setAuthenticationV2(@RequestBody(required = false) AuthenticationRequest authRequest,
+													  HttpServletRequest request, HttpServletResponse response) {
 		if (authRequest == null || authRequest.getUsername() == null || authRequest.getPassword() == null) {
 			return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
 		}
 
 		String username = authRequest.getUsername();
 		String password = authRequest.getPassword();
-		LOG.info("/api/auth username:" + username);
+		LOG.info("/api/v2/auth username:" + username);
 		Authentication authentication = authenticate(username, password, request, response, authenticationManager, userService);
 		return new ResponseEntity<>(String.valueOf(authentication.isAuthenticated()), HttpStatus.OK);
 	}
@@ -98,9 +106,21 @@ public class AuthenticationAPI {
 		return new ResponseEntity<>(String.valueOf(ok),HttpStatus.OK);
 	}
 	
-	@PostMapping(value = "/api/auth/logout")
-	public ResponseEntity<String> setLogout(HttpServletRequest request) {
-		LOG.info("/api/auth/logout");
+	@RequestMapping(value = "/api/auth/logout/{username}", method = RequestMethod.POST)
+	public ResponseEntity<String> setLogout(@PathVariable("username") String username, HttpServletRequest request) {
+		LOG.info("/api/auth/logout/{username} username:" + username);
+		User user = userService.getUser(username);
+
+		if (user != null) {
+			logout(request);
+		}
+
+		return new ResponseEntity<>(String.valueOf(true),HttpStatus.OK);
+	}
+
+	@PostMapping(value = "/api/v2/auth/logout")
+	public ResponseEntity<String> setLogoutV2(HttpServletRequest request) {
+		LOG.info("/api/v2/auth/logout");
 		User user = Common.getUser(request);
 
 		if (user != null) {

--- a/src/org/scada_lts/web/mvc/api/DataSourceAPI.java
+++ b/src/org/scada_lts/web/mvc/api/DataSourceAPI.java
@@ -64,7 +64,7 @@ public class DataSourceAPI {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/api/datasource/toggle")
+    @PostMapping(value = "/api/datasource/toggle")
     public ResponseEntity<Map<String, Object>> toggleDataSource(@RequestParam(required = false) Integer id,
                                                                 @RequestParam(required = false) String xid,
                                                                 HttpServletRequest request) {
@@ -85,7 +85,7 @@ public class DataSourceAPI {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/api/datasource/datapoints/enable")
+    @PutMapping(value = "/api/datasource/datapoints/enable")
     public ResponseEntity<List<DataPointJson>> enableAllPointsInDataSource(@RequestParam(required = false) Integer id,
                                                                            @RequestParam(required = false) String xid,
                                                                            HttpServletRequest request) {

--- a/src/org/scada_lts/web/mvc/api/PointValueAPI.java
+++ b/src/org/scada_lts/web/mvc/api/PointValueAPI.java
@@ -498,7 +498,7 @@ public class PointValueAPI {
      * @param request
      * @return
      */
-    @RequestMapping(value = "/api/point_value/setValue/{xid}/{type}/{value}", method = RequestMethod.GET)
+    @PutMapping(value = "/api/point_value/setValue/{xid}/{type}/{value}")
     public ResponseEntity<String> setValueGet(
             @PathVariable("xid") String xid,
             @PathVariable("type") int type,
@@ -680,7 +680,7 @@ public class PointValueAPI {
         }
     }
 
-    @RequestMapping(value = "/api/point_value/updateMetaDataPointByScript/{xid}", method = RequestMethod.GET)
+    @PutMapping(value = "/api/point_value/updateMetaDataPointByScript/{xid}")
     public ResponseEntity<String> updateMetaDataPointByScript(@PathVariable("xid") String xid, HttpServletRequest request) {
 
         try {
@@ -703,7 +703,7 @@ public class PointValueAPI {
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/api/point_value/updateMetaDataPointsByScript/{xid}", method = RequestMethod.GET)
+    @PutMapping(value = "/api/point_value/updateMetaDataPointsByScript/{xid}")
     public ResponseEntity<String> updateMetaDataPointsByScript(@PathVariable("xid") String xid, HttpServletRequest request) {
 
         try {
@@ -724,7 +724,7 @@ public class PointValueAPI {
         return new ResponseEntity<String>(HttpStatus.OK);
     }
 
-    @RequestMapping(value = "/api/point_value/updateAllMetaDataPointsByScript/", method = RequestMethod.GET)
+    @PutMapping(value = "/api/point_value/updateAllMetaDataPointsByScript/")
     public ResponseEntity<String> updateAllMetaDataPointsByScript(HttpServletRequest request) {
 
         try {

--- a/src/org/scada_lts/web/mvc/api/ReportsAPI.java
+++ b/src/org/scada_lts/web/mvc/api/ReportsAPI.java
@@ -84,9 +84,9 @@ public class ReportsAPI {
      * @param request     HTTP request with user data
      * @return ReportVO List
      */
-    @GetMapping(value = "/run/{id}")
+    @PostMapping(value = "/run/{id}")
     public ResponseEntity<String> runReport(@PathVariable("id") Integer id, HttpServletRequest request) {
-        LOG.info("GET::/api/reports/run");
+        LOG.info("POST::/api/reports/run");
         reportsApiService.runReport(request, null, id);
         return new ResponseEntity<>("ok", HttpStatus.OK);
     }
@@ -117,9 +117,9 @@ public class ReportsAPI {
         return new ResponseEntity<>(id, HttpStatus.OK);
     }
 
-    @GetMapping(value = "/instances/{id}/preventPurge/{preventPurge}")
+    @PutMapping(value = "/instances/{id}/preventPurge/{preventPurge}")
     public HttpEntity<Integer> setReportInstancePreventPurge(@PathVariable("id") Integer id, @PathVariable("preventPurge") Boolean preventPurge, HttpServletRequest request) {
-        LOG.info("GET::/api/reports/instances/"+id+"/preventPurge/"+preventPurge);
+        LOG.info("PUT::/api/reports/instances/"+id+"/preventPurge/"+preventPurge);
         reportsApiService.setReportInstancePreventPurge(request, id, preventPurge);
         return new ResponseEntity<>(id, HttpStatus.OK);
     }

--- a/src/org/scada_lts/web/mvc/api/ResourcesAPI.java
+++ b/src/org/scada_lts/web/mvc/api/ResourcesAPI.java
@@ -25,8 +25,7 @@ import org.scada_lts.service.ResourcesService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import javax.annotation.Resource;
 import javax.servlet.http.HttpServletRequest;
@@ -44,7 +43,7 @@ public class ResourcesAPI {
     @Resource
     private ResourcesService resourcesService;
 
-    @RequestMapping(value = "/api/resources/imagesRefresh", method = RequestMethod.GET)
+    @PostMapping(value = "/api/resources/imagesRefresh")
     public ResponseEntity<String> imagesRefresh(HttpServletRequest request) {
 
         LOG.info("/api/resources/imagesRefresh");

--- a/src/org/scada_lts/web/mvc/api/SystemSettingsAPI.java
+++ b/src/org/scada_lts/web/mvc/api/SystemSettingsAPI.java
@@ -302,7 +302,7 @@ public class SystemSettingsAPI {
         }
     }
 
-    @GetMapping(value = "/purgeNow", produces = "application/json")
+    @PostMapping(value = "/purgeNow", produces = "application/json")
     public ResponseEntity<Map<String, String>> purgeNow(HttpServletRequest request) {
         LOG.info("/api/systemSettings/purgeData");
         LOG.warn("Purging data!");
@@ -484,7 +484,7 @@ public class SystemSettingsAPI {
         }
     }
 
-    @GetMapping(value = "/purgeData", produces = "application/json")
+    @PostMapping(value = "/purgeData", produces = "application/json")
     public ResponseEntity<Map<String, String>> purgeData(HttpServletRequest request) {
         LOG.info("/api/systemSettings/purgeData");
         LOG.warn("Purging data!");

--- a/src/org/scada_lts/web/mvc/api/ViewHierarchyAPI.java
+++ b/src/org/scada_lts/web/mvc/api/ViewHierarchyAPI.java
@@ -82,7 +82,7 @@ public class ViewHierarchyAPI {
 	
 		
 	
-	@RequestMapping(value = "/api/view_hierarchy/createFolder/{name}/{parentId}", method = RequestMethod.GET)
+	@RequestMapping(value = "/api/view_hierarchy/createFolder/{name}/{parentId}", method = RequestMethod.POST)
 	public ResponseEntity<Object> createFolder(@PathVariable("name") String name, @PathVariable("parentId") int parentId, HttpServletRequest request) {
 		
 		LOG.info("/api/view_hierarchy/createFolder/{name}:"+name+" {parentId}:"+parentId);


### PR DESCRIPTION
 Updated REST endpoints for state-changing operations and moved auth credentials into JSON body, then aligned frontend callers, security rules, and docs to match the new methods and paths.

  - Backend mappings switched to POST/PUT where needed and auth/logout paths simplified in src/org/scada_lts/web/mvc/api/AuthenticationAPI.java, src/org/scada_lts/web/mvc/api/DataSourceAPI.java, src/org/scada_lts/web/mvc/api/ PointValueAPI.java, src/org/scada_lts/web/mvc/api/ReportsAPI.java, src/org/scada_lts/web/mvc/api/SystemSettingsAPI.java, src/org/scada_lts/web/mvc/api/ResourcesAPI.java, src/org/scada_lts/web/mvc/api/ViewHierarchyAPI.java
  - Report endpoint method guards updated in WebContent/WEB-INF/spring-security.xml
  - Vuex/JSP/Cypress callers updated for new methods and auth body in scadalts-ui/src/store/dataSource/index.js, scadalts-ui/src/store/reports/index.js, scadalts-ui/src/store/systemSettings/index.js, WebContent/WEB-INF/jsp/ systemSettings.jsp, scadalts-ui/cypress/support/commands.js, scadalts-ui/cypress/integration/ScadaLTS_Views/modern_charts.cy.js, WebContent/resources/vue-mixins/shared/mixins-export-import.js
  - OpenAPI and migration notes updated in doc/RESTAPI/ScadaLTS_API_OAS3.yaml and doc/RESTAPI/ENDPOINT_MIGRATION.md, plus a small README tweak in scadalts-ui/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized API endpoints to use appropriate HTTP methods: state-changing operations now use POST/PUT instead of GET for better REST compliance.
  * Updated authentication endpoint to accept credentials via request body instead of URL path for improved security.

* **Documentation**
  * Updated API documentation to reflect HTTP method changes and new authentication request schema.

* **Tests**
  * Updated test suite to align with new authentication and endpoint changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->