### PR TITLE
#3242 Fixed BACnet Read:

### DIFF
--- a/src/com/serotonin/mango/rt/dataSource/bacnet/BACnetIPDataSourceRT.java
+++ b/src/com/serotonin/mango/rt/dataSource/bacnet/BACnetIPDataSourceRT.java
@@ -223,7 +223,7 @@ public class BACnetIPDataSourceRT extends PollingDataSource implements DeviceEve
 
         // Check if the remote device is in the local list yet.
         RemoteDevice d = localDevice.getRemoteDevice(address, network);
-        if (d == null) {
+        if (!isReadyDevice(d)) {
             // Send a whois to get remote device data.
             try {
                 localDevice.sendUnconfirmed(address, null, new WhoIsRequest());
@@ -248,12 +248,12 @@ public class BACnetIPDataSourceRT extends PollingDataSource implements DeviceEve
 
                 // Check again for the device
                 d = localDevice.getRemoteDevice(address, network);
-                if (d != null)
+                if (isReadyDevice(d))
                     break;
             }
         }
 
-        if (d == null) {
+        if (!isReadyDevice(d)) {
             // If we still don't have the device, try to get it manually.
             try {
                 d = localDevice.findRemoteDevice(address, network, locator.getRemoteDeviceInstanceNumber());
@@ -269,7 +269,7 @@ public class BACnetIPDataSourceRT extends PollingDataSource implements DeviceEve
             }
         }
 
-        if (d == null) {
+        if (!isReadyDevice(d)) {
             // If we still don't have the device, call it in.
             fireDeviceExceptionEvent(dataPoint,"event.bacnet.deviceError", address.toIpString());
             disablePoint(dataPoint);
@@ -818,5 +818,9 @@ public class BACnetIPDataSourceRT extends PollingDataSource implements DeviceEve
     @Override
     public int getUpdateTimeExceededUpdatePeriodEventId() {
         return UPDATE_TIME_EXCEEDED_UPDATE_PERIOD_EXCEPTION_EVENT;
+    }
+
+    private boolean isReadyDevice(RemoteDevice d) {
+        return d != null && d.getSegmentationSupported() != null;
     }
 }


### PR DESCRIPTION
- Corrected BACnetIPDataSourceRT: Added check SegmentationSupported parameter from RemoteDevice, until this field is set, it will try to get the remote device;

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened device initialization validation to ensure devices are fully configured with required information before becoming available for use.

* **Refactor**
  * Refactored device readiness determination to use a dedicated validation method, reducing code duplication and improving maintainability across device discovery operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->