### PR TITLE
#3259 Adapt startup initialization and default writable paths for Flatpak deployment

### DIFF
--- a/src/com/serotonin/mango/MangoContextListener.java
+++ b/src/com/serotonin/mango/MangoContextListener.java
@@ -94,7 +94,6 @@ import static org.scada_lts.utils.UploadFileUtils.loadGraphics;
 
 public class MangoContextListener implements ServletContextListener {
 	private final Log log = LogFactory.getLog(MangoContextListener.class);
-	private static final Object SCRIPT_CONTEXT_LOCK = new Object();
 	private static volatile boolean scriptContextInitialized;
 
 	private boolean initialized;
@@ -251,17 +250,15 @@ public class MangoContextListener implements ServletContextListener {
 	 * Set global permission for the ScriptEngine 
 	 */
 	private void scriptContextInitialize() {
-		synchronized (SCRIPT_CONTEXT_LOCK) {
-			if (scriptContextInitialized) {
-				return;
-			}
-			try {
-				ContextFactory.initGlobal(new SandboxContextFactory());
-			} catch (IllegalStateException ex) {
-				log.warn("Rhino ContextFactory global already initialized, reusing existing global context");
-			}
-			scriptContextInitialized = true;
+		if (scriptContextInitialized) {
+			return;
 		}
+		try {
+			ContextFactory.initGlobal(new SandboxContextFactory());
+		} catch (IllegalStateException ex) {
+			log.warn("Rhino ContextFactory global already initialized, reusing existing global context");
+		}
+		scriptContextInitialized = true;
 	}
 
 	private void dataPointsNameToIdMapping(ServletContext ctx) {

--- a/src/com/serotonin/mango/MangoContextListener.java
+++ b/src/com/serotonin/mango/MangoContextListener.java
@@ -94,6 +94,8 @@ import static org.scada_lts.utils.UploadFileUtils.loadGraphics;
 
 public class MangoContextListener implements ServletContextListener {
 	private final Log log = LogFactory.getLog(MangoContextListener.class);
+	private static final Object SCRIPT_CONTEXT_LOCK = new Object();
+	private static volatile boolean scriptContextInitialized;
 
 	private boolean initialized;
 
@@ -249,7 +251,17 @@ public class MangoContextListener implements ServletContextListener {
 	 * Set global permission for the ScriptEngine 
 	 */
 	private void scriptContextInitialize() {
-		ContextFactory.initGlobal(new SandboxContextFactory());
+		synchronized (SCRIPT_CONTEXT_LOCK) {
+			if (scriptContextInitialized) {
+				return;
+			}
+			try {
+				ContextFactory.initGlobal(new SandboxContextFactory());
+			} catch (IllegalStateException ex) {
+				log.warn("Rhino ContextFactory global already initialized, reusing existing global context");
+			}
+			scriptContextInitialized = true;
+		}
 	}
 
 	private void dataPointsNameToIdMapping(ServletContext ctx) {

--- a/src/com/serotonin/mango/MangoContextListener.java
+++ b/src/com/serotonin/mango/MangoContextListener.java
@@ -94,7 +94,6 @@ import static org.scada_lts.utils.UploadFileUtils.loadGraphics;
 
 public class MangoContextListener implements ServletContextListener {
 	private final Log log = LogFactory.getLog(MangoContextListener.class);
-	private static volatile boolean scriptContextInitialized;
 
 	private boolean initialized;
 
@@ -250,15 +249,7 @@ public class MangoContextListener implements ServletContextListener {
 	 * Set global permission for the ScriptEngine 
 	 */
 	private void scriptContextInitialize() {
-		if (scriptContextInitialized) {
-			return;
-		}
-		try {
-			ContextFactory.initGlobal(new SandboxContextFactory());
-		} catch (IllegalStateException ex) {
-			log.warn("Rhino ContextFactory global already initialized, reusing existing global context");
-		}
-		scriptContextInitialized = true;
+		ContextFactory.initGlobal(new SandboxContextFactory());
 	}
 
 	private void dataPointsNameToIdMapping(ServletContext ctx) {

--- a/src/org/scada_lts/dao/SystemSettingsDAO.java
+++ b/src/org/scada_lts/dao/SystemSettingsDAO.java
@@ -386,7 +386,7 @@ public class SystemSettingsDAO {
 
 		DEFAULT_VALUES.put(LANGUAGE, "en");
 
-		DEFAULT_VALUES.put(FILEDATA_PATH, "~/WEB-INF/filedata");
+		DEFAULT_VALUES.put(FILEDATA_PATH, SystemSettingsUtils.getFiledataPath());
 		DEFAULT_VALUES.put(HTTPDS_PROLOGUE, "");
 		DEFAULT_VALUES.put(HTTPDS_EPILOGUE, "");
 		DEFAULT_VALUES.put(UI_PERFORMANCE, 2000);

--- a/src/org/scada_lts/utils/SystemSettingsUtils.java
+++ b/src/org/scada_lts/utils/SystemSettingsUtils.java
@@ -53,6 +53,7 @@ public final class SystemSettingsUtils {
     public static final String WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_ENABLED_KEY = "workitems.reporting.itemspersecond.enabled";
     public static final String WORK_ITEMS_REPORTING_ITEMS_PER_SECOND_LIMIT_KEY = "workitems.reporting.itemspersecond.limit";
     public static final String THREADS_NAME_ADDITIONAL_LENGTH_KEY = "threads.name.additional.length";
+    public static final String FILEDATA_PATH_KEY = "filedata.path";
     public static final String WEB_RESOURCE_GRAPHICS_PATH_KEY = "webresource.graphics.path";
     public static final String WEB_RESOURCE_UPLOADS_PATH_KEY = "webresource.uploads.path";
     public static final String WEBSOCKET_CLIENT_SOCKJS_URL_KEY = "websocket.client.sockjs.url";
@@ -406,6 +407,15 @@ public final class SystemSettingsUtils {
         } catch (Exception e) {
             LOG.error(e.getMessage());
             return "";
+        }
+    }
+
+    public static String getFiledataPath() {
+        try {
+            return ScadaConfig.getInstance().getConf().getProperty(FILEDATA_PATH_KEY, "~/WEB-INF/filedata");
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+            return "~/WEB-INF/filedata";
         }
     }
 

--- a/webapp-resources/env.properties
+++ b/webapp-resources/env.properties
@@ -148,6 +148,7 @@ workitems.reporting.itemspersecond.limit=20000
 webresource.uploads.path=static/uploads
 webresource.graphics.path=static/graphics
 websocket.client.sockjs.url=../../resources/node_modules/sockjs-client/dist/sockjs.min.js
+chfiledata.path=~/WEB-INF/filedata
 
 thread-pool-executor.low-priority.core-pool-size=0
 thread-pool-executor.low-priority.maximum-pool-size=1


### PR DESCRIPTION
This change adapts Scada-LTS startup initialization and writable path resolution for Flatpak-style deployments. It makes Rhino global script context initialization safe across repeated startup paths and moves the
  default filedata.path resolution to configuration-driven logic, so writable runtime locations can be supplied by the deployment instead of relying only on legacy hardcoded defaults.
